### PR TITLE
Replace crypto@1.0.1 with nodejs built-in.

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "@types/properties-reader": "0.0.1",
     "@here/olp-sdk-fetch": "0.9.0",
-    "properties-reader": "0.3.1",
-    "crypto": "1.0.1"
+    "properties-reader": "0.3.1"
   },
   "devDependencies": {
     "@types/chai": "4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,11 +2323,6 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"


### PR DESCRIPTION
The crypto@1.0.1 is no longer supported.
We can use https://nodejs.org/api/crypto.html

Relates-To: OSSPROJECT-100
Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>