### PR TITLE
Add new package olp-sdk-tile-provider

### DIFF
--- a/@here/olp-sdk-tile-provider/README.md
+++ b/@here/olp-sdk-tile-provider/README.md
@@ -1,0 +1,63 @@
+# Tile Provider
+
+# Overview
+
+This repository contains the complete source code for the OLP EDGE SDK TS Tile Provider `@here/olp-sdk-tile-provider` project. `olp-sdk-tile-provider` is a TypeScript library to work with tile data from the OLP catalogs.
+
+# Development
+
+## Prerequisites
+
+The following NPM packages are required to build/test the library:
+
+    - node: >= 10.0.0
+    - npm: >= 6.0.0
+
+## Building
+
+Open a command prompt of the working tree's root directory and type:
+
+```sh
+npm install
+npm run build
+```
+
+## Testing
+
+Open a command prompt of the working tree's root directory and type:
+
+```sh
+npm run test
+```
+
+## Usage of Bundle functionality
+
+If you want to have a compiled project, you can use bundle commands. After running each of the following commands in the `dist/@here/olp-sdk-tile-provider/bundle` folder from the root folder, you get the js bundled files.
+
+To get bundled files with a source map, run:
+
+```sh
+npm run bundle
+```
+
+To get minified version for production, run:
+
+```sh
+npm run bundle:prod
+```
+
+To get bundled and minified js files, run:
+
+```sh
+npm run prepublish-bundle
+```
+
+## License
+
+Copyright (C) 2018-2019 HERE Europe B.V.
+
+See the [LICENSE](https://main.gitlab.in.here.com/olp/edge/olp-sdk/edge-sdk-for-ts/blob/master/@here/olp-sdk-tile-provider/LICENSE) file in the root of this project for license details about using OLP SDK.
+
+In addition, please note that the fonts are under a different set of licenses.
+
+For other use cases not listed in the license terms, please [contact us](https://developer.here.com/contact-us).

--- a/@here/olp-sdk-tile-provider/index.ts
+++ b/@here/olp-sdk-tile-provider/index.ts
@@ -1,0 +1,21 @@
+
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+export * from "./lib/TileProvider";

--- a/@here/olp-sdk-tile-provider/lib/TileProvider.ts
+++ b/@here/olp-sdk-tile-provider/lib/TileProvider.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  CatalogClient,  
+  DataStoreContext,
+  mortonCodeFromQuadKey,
+  NotFoundError,
+  QuadKey
+} from "@here/olp-sdk-dataservice-read/";
+
+/**
+ * Specify the options of the Hype datasource.
+ */
+export interface TileProviderOptions {
+  /**
+   * Specify which layer to use.
+   */
+  layerId: string;
+
+  /**
+   * Specify the environment, select from "here", "here-dev", "here-cn" or "here-cn-dev".
+   */
+  environment: string;
+
+  /**
+   * Specify which version of CatalogClient should be used.
+   */
+  catalogVersion?: number;
+
+  /**
+   * HRN to the catalog, where a requested layer with tiles is.
+   */
+  catalogHrn: string;
+
+  /**
+   * Return async promise with token from authentication module.
+   */
+  getToken: () => Promise<string>;
+}
+
+/**
+ * The `TileProvider` is a [[DataProvider]] which retrieves heretiles (partition id in any of the specified
+ * versions of the catalog) by the DataServiceRead.
+ *
+ */
+export class TileProvider {
+  // tslint:disable-next-line: deprecation
+  private m_catalogClient?: CatalogClient;
+
+  /**
+   * Construct a new `TileProvider` with the specified options.
+   *
+   * @param m_options Specify options like layer, URL and version.
+   *
+   */
+  constructor(private readonly m_options: TileProviderOptions) {}
+
+  /**
+   * Returns the underlying catalog client.
+   *
+   * **Note**: The data provider must be connected before this method can be called, so make sure
+   * that `ready()` returns `true` before calling it.
+   *
+   * @returns The catalog client this data provider uses.
+   */
+  catalogClient(): CatalogClient | undefined {
+    return this.m_catalogClient;
+  }
+
+
+}

--- a/@here/olp-sdk-tile-provider/package.json
+++ b/@here/olp-sdk-tile-provider/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "@here/olp-sdk-tile-provider",
+  "version": "0.9.0",
+  "description": "This module is able to connect to the datastore and extract the partitions with schemas heretile from the version and whitelist layers.",
+  "main": "index.js",
+  "typings": "index",
+  "directories": {
+    "test": "test",
+    "lib": "lib"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "tslint -c tslint.json -p tsconfig.json",
+    "test": "mocha > xunit.xml",
+    "coverage": "nyc mocha > xunit.xml",
+    "prepare": "tsc --sourceMap false",
+    "bundle": "webpack --env.NODE_ENV=development",
+    "bundle:prod": "webpack --env.NODE_ENV=production",
+    "prepublish-bundle": "npm run bundle && npm run bundle:prod"
+  },
+  "nyc": {
+    "include": [
+      "lib/**/*.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "text",
+      "html"
+    ],
+    "sourceMap": true,
+    "instrument": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://main.gitlab.in.here.com/olp/edge/olp-sdk/edge-sdk-for-ts.git",
+    "directory": "@here/olp-sdk-tile-provider"
+  },
+  "author": {
+    "name": "HERE Europe B.V.",
+    "url": "https://here.com"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@here/olp-sdk-tile-provider": "0.9.0",
+    "@here/olp-sdk-fetch": "0.9.0"
+  },
+  "devDependencies": {
+    "@types/chai": "4.2.3",
+    "@types/mocha": "5.2.7",
+    "@types/node": "12.7.5",
+    "@types/sinon": "7.0.3",
+    "@types/sinon-chai": "3.2.3",
+    "awesome-typescript-loader": "5.2.1",
+    "chai": "4.2.0",
+    "glob": "7.1.4",
+    "husky": "3.0.3",
+    "lint-staged": "9.2.5",
+    "mocha": "6.2.0",
+    "nyc": "14.1.1",
+    "prettier": "1.18.2",
+    "sinon": "7.4.2",
+    "sinon-chai": "3.3.0",
+    "source-map-support": "0.5.13",
+    "ts-node": "8.4.1",
+    "tslint": "5.20.0",
+    "tslint-config-prettier": "1.18.0",
+    "typedoc": "0.15.0",
+    "typescript": "3.5.3",
+    "webpack": "4.40.2",
+    "webpack-cli": "3.3.9"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{ts}": [
+      "prettier --write",
+      "git add"
+    ]
+  }
+}

--- a/@here/olp-sdk-tile-provider/test/TileProvider.test.ts
+++ b/@here/olp-sdk-tile-provider/test/TileProvider.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */

--- a/@here/olp-sdk-tile-provider/test/mocha.opts
+++ b/@here/olp-sdk-tile-provider/test/mocha.opts
@@ -1,0 +1,7 @@
+--require  ts-node/register
+--require source-map-support/register
+--full-trace
+--bail
+--check-leaks
+--reporter xunit
+test/**/*.test.ts

--- a/@here/olp-sdk-tile-provider/tsconfig.json
+++ b/@here/olp-sdk-tile-provider/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": [
+        "./lib",
+        "./test",
+        "index.ts"
+    ]
+}

--- a/@here/olp-sdk-tile-provider/tslint.json
+++ b/@here/olp-sdk-tile-provider/tslint.json
@@ -1,0 +1,155 @@
+{
+  "extends": ["tslint:recommended", "tslint-config-prettier"],
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "object-literal-sort-keys": false,
+    "max-classes-per-file": false,
+    "variable-name": [true, "check-format", "allow-leading-underscore", "allow-snake-case"],
+
+    "arrow-return-shorthand": true,
+    "await-promise": true,
+    "ban-comma-operator": true,
+    "callable-types": true,
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "deprecation": {
+      "severity": "warn"
+    },
+    "eofline": true,
+    "forin": true,
+    "import-blacklist": [
+      true,
+      "rxjs/Rx"
+    ],
+    "import-spacing": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "interface-over-type-literal": true,
+    "label-position": true,
+    "max-line-length": [
+      true,
+      {
+        "limit": 140,
+        "ignore-pattern":
+        {
+          "type": "string"
+        }
+      }
+    ],
+    "member-access": false,
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "static-field",
+          "instance-field",
+          "static-method",
+          "instance-method"
+        ]
+      }
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-conditional-assignment": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-imports": true,
+    "no-duplicate-super": true,
+    "no-duplicate-switch-case": true,
+    "no-empty": false,
+    "no-empty-interface": true,
+    "no-eval": true,
+    "no-for-in-array": true,
+    "no-import-side-effect": true,
+    "no-inferrable-types": [
+      true,
+      "ignore-params"
+    ],
+    "no-inferred-empty-object-type": false,
+    "no-internal-module": true,
+    "no-invalid-template-strings": true,
+    "no-invalid-this": true,
+    "no-magic-numbers": [
+      true,
+      -1, 0, 1, 2
+    ],
+    "no-misused-new": true,
+    "no-namespace": true,
+    "no-non-null-assertion": false,
+    "no-parameter-reassignment": false,
+    "no-reference": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-string-throw": true,
+    "no-sparse-arrays": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": false,
+    "no-unnecessary-initializer": true,
+    "no-unsafe-finally": true,
+    "no-unused-expression": false,
+    "no-var-keyword": true,
+    "no-var-requires": true,
+    "no-void-expression": true,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "only-arrow-functions": [
+      true,
+      "allow-declarations",
+      "allow-named-functions"
+    ],
+    "prefer-const": true,
+    "promise-function-async": true,
+    "quotemark": [
+      true,
+      "double"
+    ],
+    "radix": true,
+    "restrict-plus-operands": true,
+    "semicolon": [
+      true,
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "unified-signatures": true,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
+}

--- a/@here/olp-sdk-tile-provider/webpack.config.js
+++ b/@here/olp-sdk-tile-provider/webpack.config.js
@@ -1,0 +1,36 @@
+const path = require("path");
+const packageInfo = require('./package.json');
+
+module.exports = env => {
+  const isProd = env.NODE_ENV === "production";
+
+  return {
+    mode: env.NODE_ENV,
+    devtool: isProd ? undefined : "source-map",
+    resolve: {
+      extensions: [".ts", ".js"]
+    },
+    entry: "./index.ts",
+    output: {
+      filename: `olp-sdk-tile-provider.${packageInfo.version}${isProd ? '.min' : '.dev'}.js`,
+      path: path.resolve(__dirname, `dist/bundle`),
+      libraryTarget: "umd",
+      globalObject: 'this'
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          loader: "awesome-typescript-loader",
+          exclude: /node_modules/,
+          options: {
+              onlyCompileBundledFiles: true
+          }
+        }
+      ]
+    },
+    node: {
+        fs: 'empty'
+      }
+  };
+};


### PR DESCRIPTION
Created new package olp-sdk-tile-provider.
Details: New package is created for perform migration of HypeDataProvider functionality.

Relates-To: OLPEDGE-447

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>
