### PR TITLE
Fix build for web process fails.

### DIFF
--- a/@here/olp-sdk-authentication/README.md
+++ b/@here/olp-sdk-authentication/README.md
@@ -21,20 +21,37 @@ const auth = new UserAuth(config);
 Create an instance of UserAuth class before instantiating any data sources:
 
 ```typescript
+/**
+ * A function requestToken is used to obtain the access token.
+ *
+ * Client can provide own implementation or can use from @here/olp-sdk-authentication.
+ *
+ * There are two functions that work for browser and NodeJS.
+ * UserAuth can use requestToken() from requestToken.web.ts for browser
+ * or requestToken() from requestToken.ts for NodeJS.
+ *
+ * When a function imports a function using import { requestToken } from "@here/olp-sdk-authentication",
+ * the code automatically applies the corresponding function that is applicable to access browser or NodeJS.
+ *
+ * The following code is applicable both for browser and NodeJS.
+ */
+
+import { UserAuth, requestToken } from "@here/olp-sdk-authentication";
+
 const userAuth = new UserAuth({
     env: "here",
     credentials: {
         accessKeyId: "replace-with-your-access-key-id",
         accessKeySecret: "replace-with-your-access-key-secret"
-    }
+    },
+    tokenRequester: requestToken
 });
 ```
 
 Get token:
 
 ```typescript
-await userAuth.setCredentials();
-const token: string = await userAuth.fetchToken();
+const token: string = await userAuth.getToken();
  ```
 
 ## Usage with import credentials from file
@@ -42,8 +59,9 @@ Download your credentials.properties file from [OLP website](https://developer.h
 Create an instance of UserAuth class and set the path to the file with credentials:
 
 ```typescript
-
-const userAuth = UserAuth.setCredentialsFromFile("replace-with-your-path-to-credentials.properties");
+import { UserAuth, requestToken } from "@here/olp-sdk-authentication";
+const credentials = loadCredentialsFromFile("replace-with-your-path-to-credentials.properties");
+const userAuth = new UserAuth({credentials, tokenRequester: requestToken});
 
 ```
 

--- a/@here/olp-sdk-authentication/lib/loadCredentialsFromFile.ts
+++ b/@here/olp-sdk-authentication/lib/loadCredentialsFromFile.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as PropertiesReader from "properties-reader";
+import { AuthCredentials } from "./UserAuth";
+
+ /**
+  * Parser for NodeJs usage.
+  *
+  * Parse credentials.properties file from
+  * [OLP website](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html)
+  * and retrieve object response with the credentials.
+  *
+  * @param path Path to credentials file.
+  * @throws Error if the parsing was not success.
+  * @returns Object with user`s credentials.
+  */
+ export function loadCredentialsFromFile(path: string): AuthCredentials {
+    const config = PropertiesReader(path);
+    const configAccessKeyIdValueName = "here.access.key.id";
+    const configAccessKeySecretValueName = "here.access.key.secret";
+
+    const parseValueFromConfig = (value: string | number | boolean | null, valueName: string): string => {
+        if (!value) {
+            throw new Error(`Error parsing value ${valueName} from configuration`);
+        }
+
+        return value.toString();
+    };
+
+    return {
+        accessKeyId: parseValueFromConfig(config.get(configAccessKeyIdValueName), configAccessKeyIdValueName),
+        accessKeySecret: parseValueFromConfig(config.get(configAccessKeySecretValueName), configAccessKeySecretValueName)
+    };
+ }

--- a/@here/olp-sdk-authentication/test/OAuth.test.ts
+++ b/@here/olp-sdk-authentication/test/OAuth.test.ts
@@ -21,6 +21,7 @@ import { assert } from "chai";
 import { requestToken, UserAuth } from "../index";
 
 import fetchMock = require("fetch-mock");
+import { loadCredentialsFromFile } from "../lib/loadCredentialsFromFile";
 
 const REPLY_TIMEOUT_MS = 600;
 const MOCK_CREATED_TIME = 1550777140;
@@ -88,8 +89,10 @@ describe("oauth-request-offline", () => {
 
     it("getTokenAuthModeFile", async () => {
         let token: string | null = null;
-        let credentialsFilePath = "./test/test-credentials.properties";
-        let userAuth = await UserAuth.setCredentialsFromFile(credentialsFilePath);
+        const credentialsFilePath = "./test/test-credentials.properties";
+        const credentials = loadCredentialsFromFile(credentialsFilePath);
+
+        const userAuth = new UserAuth({credentials, tokenRequester: requestToken});
 
         try {
             token = await userAuth.getToken();
@@ -108,7 +111,8 @@ describe("oauth-request-offline", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         try {
@@ -127,7 +131,8 @@ describe("oauth-request-offline", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         fetchMock.post("https://account.api.here.com/verify/accessToken", {
@@ -169,7 +174,8 @@ describe("oauth-request-lookupapi", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         fetchMock.get("https://account.api.here.com/user/me", {
@@ -216,7 +222,8 @@ describe("oauth-request-lookupapi", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         fetchMock.get("https://stg.account.api.here.com/user/me", {
@@ -263,7 +270,8 @@ describe("oauth-request-lookupapi", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         fetchMock.get("https://elb.cn-northwest-1.account.hereapi.cn/user/me", {
@@ -310,7 +318,8 @@ describe("oauth-request-lookupapi", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         fetchMock.get(
@@ -360,7 +369,8 @@ describe("oauth-request-lookupapi", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         fetchMock.get("http://localhost/user/me", {
@@ -406,7 +416,8 @@ describe("oauth-request-lookupapi", () => {
             credentials: {
                 accessKeyId: mock_id,
                 accessKeySecret: mock_secret
-            }
+            },
+            tokenRequester: requestToken
         });
 
         fetchMock.get("https://account.api.here.com/user/me", {

--- a/@here/olp-sdk-authentication/test/loadCredentialsFromFile.test.ts
+++ b/@here/olp-sdk-authentication/test/loadCredentialsFromFile.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { assert } from "chai";
+import { loadCredentialsFromFile } from "../lib/loadCredentialsFromFile";
+
+describe("loadCredentialsFromFile", () => {
+    it("should return correct AuthCredentials", () => {
+        const credentials = loadCredentialsFromFile("./test/test-credentials.properties");
+
+        assert.strictEqual(credentials.accessKeyId, "Tt7wZRTAar");
+        assert.strictEqual(credentials.accessKeySecret, "khcy1LMBtMZsRVn1-dn7riw9x8");
+    });
+
+    it("should throw an error", () => {
+        try {
+            loadCredentialsFromFile("./test/test-error-credentials.properties");
+        } catch (error) {
+            assert.strictEqual(error.message, "Error parsing value here.access.key.id from configuration");
+        }
+    });
+});

--- a/@here/olp-sdk-authentication/test/test-error-credentials.properties
+++ b/@here/olp-sdk-authentication/test/test-error-credentials.properties
@@ -1,0 +1,5 @@
+here.user.id = test-user-id
+here.client.id = test-client-id
+here.access.key.id =
+here.access.key.secret = khcy1LMBtMZsRVn1-dn7riw9x8
+here.token.endpoint.url = https://account.api.here.com/oauth2/token


### PR DESCRIPTION
The issue was about using NodeJS related code for browser.

The NodeJS related code moved to the separate place.
The api changed a bit to correctly injecting NodeJS code only if the target is NodeJS.
The Readme and unit tests updated.

Resolves: OLPSUP-8035
Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>