### PR TITLE
Fix build for web fails for dataservice-read.

### DIFF
--- a/@here/olp-sdk-authentication/tsconfig.json
+++ b/@here/olp-sdk-authentication/tsconfig.json
@@ -6,6 +6,7 @@
     "include": [
         "./lib",
         "./test",
-        "index.ts"
+        "index.ts",
+        "index.web.ts"
     ]
 }

--- a/@here/olp-sdk-dataservice-read/index.web.ts
+++ b/@here/olp-sdk-dataservice-read/index.web.ts
@@ -17,9 +17,6 @@
  * License-Filename: LICENSE
  */
 
-// tslint:disable-next-line: no-import-side-effect
-import "@here/olp-sdk-fetch";
-
 export * from "./lib/DataStoreClient";
 export * from "./lib/CatalogClient";
 export * from "./lib/HRN";

--- a/@here/olp-sdk-dataservice-read/lib/DataStoreClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/DataStoreClient.ts
@@ -17,9 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { ArtifactApi, ConfigApi } from "@here/olp-sdk-dataservice-api";
-import { GetSchemaResponse } from "@here/olp-sdk-dataservice-api/lib/artifact-api";
-import { CatalogsListResult } from "@here/olp-sdk-dataservice-api/lib/config-api";
+import { ArtifactApi, ConfigApi} from "@here/olp-sdk-dataservice-api";
 import { ErrorHTTPResponse } from "./CatalogClientCommon";
 import { DataStoreContext } from "./DataStoreContext";
 import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
@@ -44,7 +42,7 @@ export class DataStoreClient {
      * @param schemaHrn String representing schema HRN.
      * @returns Object with schema details.
      */
-    async getSchemaDetails(schemaHrn: string): Promise<GetSchemaResponse> {
+    async getSchemaDetails(schemaHrn: string): Promise<ArtifactApi.GetSchemaResponse> {
         const artifactBaseUrl = await this.context.getBaseUrl("artifact");
 
         return ArtifactApi.getSchemaUsingGET(
@@ -120,7 +118,7 @@ export class DataStoreClient {
      * @param schemaHrn Schema HRN of layers to look for.
      * @returns A promise with list of catalogs and their layers.
      */
-    async getCatalogsBySchema(schemaHrn: string): Promise<CatalogsListResult> {
+    async getCatalogsBySchema(schemaHrn: string): Promise<ConfigApi.CatalogsListResult> {
         const configBaseUrl = await this.context.getBaseUrl("config");
         return ConfigApi.getCatalogs(
             new DataStoreRequestBuilder(

--- a/@here/olp-sdk-dataservice-read/lib/DataStoreDownloadManager.ts
+++ b/@here/olp-sdk-dataservice-read/lib/DataStoreDownloadManager.ts
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-// tslint:disable-next-line: no-import-side-effect
-import "@here/olp-sdk-fetch";
 import { DownloadManager } from "./DownloadManager";
 
 /** @internal

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -3,7 +3,8 @@
   "version": "0.9.0",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to reading data from OLP catalogs",
   "main": "dist/@here/olp-sdk-dataservice-read/index.js",
-  "typings": "dist/@here/olp-sdk-dataservice-read/index",
+  "browser": "dist/@here/olp-sdk-dataservice-read/index.web.js",
+  "typings": "dist/@here/olp-sdk-dataservice-read/index.web",
   "directories": {
     "test": "test",
     "lib": "lib"

--- a/@here/olp-sdk-dataservice-read/test/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/CatalogClient.test.ts
@@ -17,7 +17,8 @@
  * License-Filename: LICENSE
  */
 
-import * as utils from "../lib/partitioning/QuadKeyUtils";
+import "@here/olp-sdk-fetch";
+
 import { assert } from "chai";
 import sinon = require("sinon");
 

--- a/@here/olp-sdk-dataservice-read/tsconfig.json
+++ b/@here/olp-sdk-dataservice-read/tsconfig.json
@@ -6,6 +6,7 @@
     "include": [
         "./lib",
         "./test",
-        "index.ts"
+        "index.ts",
+        "index.web.ts"
     ]
 }

--- a/@here/olp-sdk-fetch/tsconfig.json
+++ b/@here/olp-sdk-fetch/tsconfig.json
@@ -6,6 +6,7 @@
     "include": [
         "./lib",
         "./test",
-        "index.ts"
+        "index.ts",
+        "index.web.ts"
     ]
 }


### PR DESCRIPTION
The issue was about using NodeJS related code for the browser.

The NodeJS related code moved to a separate place
and will be injected only if the target of the build is NodeJS

The imports from dataservice-api was improved

Resolves: OLPSUP-8069

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>