### PR TITLE
Align Version and Volatile Layers with DatastoreApi

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -47,7 +47,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@types/properties-reader": "0.0.1",
-    "@here/olp-sdk-fetch": "0.9.0",
+    "@here/olp-sdk-fetch": "0.9.1",
     "properties-reader": "0.3.1"
   },
   "devDependencies": {

--- a/@here/olp-sdk-dataservice-api/lib/RequestBuilder.ts
+++ b/@here/olp-sdk-dataservice-api/lib/RequestBuilder.ts
@@ -133,9 +133,25 @@ export abstract class RequestBuilder {
     }
 
     /**
+     * Helper method to download the resource.
+     *
+     * @param urlObj the URL to fetch.
+     */
+    async requestBlob(urlObj: UrlBuilder, init?: RequestOptions): Promise<Response> {
+        return this.downloadBlob(urlObj.url, init);
+    }
+
+    /**
      * Implement this function to download the given url as JSON object.
      *
      * @param url The URL to download.
      */
     abstract download<T>(url: string, init?: RequestOptions): Promise<T>;
+
+    /**
+     * Implement this function to download the given url as Blob object.
+     *
+     * @param url The URL to download.
+     */
+    abstract downloadBlob(url: string, init?: RequestOptions): Promise<Response>;
 }

--- a/@here/olp-sdk-dataservice-api/lib/artifact-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/artifact-api.ts
@@ -230,8 +230,8 @@ export async function getArtifactFileUsingGET(
 export async function getArtifactUsingGET(
     builder: RequestBuilder,
     params: { artifactHrn: string }
-): Promise<GetArtifactResponse> {
-    const baseUrl = "/artifact/{artifactHrn}".replace(
+): Promise<Response> {
+    const baseUrl = "/{artifactHrn}".replace(
         "{artifactHrn}",
         UrlBuilder.toString(params["artifactHrn"])
     );
@@ -244,7 +244,7 @@ export async function getArtifactUsingGET(
         headers
     };
 
-    return builder.request<GetArtifactResponse>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**

--- a/@here/olp-sdk-dataservice-api/lib/blob-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/blob-api.ts
@@ -379,7 +379,7 @@ export async function getBlob(
         billingTag?: string;
         range?: string;
     }
-): Promise<string> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/data/{dataHandle}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{dataHandle}", UrlBuilder.toString(params["dataHandle"]));
@@ -396,7 +396,7 @@ export async function getBlob(
         headers["Range"] = params["range"] as string;
     }
 
-    return builder.request<string>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**

--- a/@here/olp-sdk-dataservice-api/lib/coverage-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/coverage-api.ts
@@ -50,12 +50,42 @@ export interface CatalogAdminAreas {
     states?: string[];
 }
 
-export interface Size {
-    bbox?: BoundingBox;
-    centroid?: string;
-    proccessedTimestamp?: string;
-    size?: string;
-    version?: string;
+/**
+ * An interface of the bounding box data for the layer.
+ */
+export interface LayerBoundingBox {
+    east: number;
+    south: number;
+    north: number;
+    west: number;
+}
+
+/**
+ * An interface of the catalog layer summary for one zoom level.
+ */
+export interface LayerLevelSummary {
+    boundingBox: LayerBoundingBox;
+    size: number;
+    processedTimestamp: number;
+    centroid: number;
+    minPartitionSize: number;
+    maxPartitionSize: number;
+    version: number;
+    totalPartitions: number;
+}
+
+/**
+ * An interface for the catalog layer summary data.
+ */
+export interface LayerSummary {
+    /** A catalog HRN. */
+    catalogHRN: string;
+    /** A layer name. */
+    layer: string;
+    /** A layer summary for multiple zoom levels. */
+    levelSummary: {
+        [index: number]: LayerLevelSummary;
+    };
 }
 
 /* ===================================================================
@@ -101,7 +131,7 @@ export async function getDataCoverageAdminAreas(
 export async function getDataCoverageSizeMap(
     builder: RequestBuilder,
     params: { layerId: string; datalevel: string }
-): Promise<string> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/heatmap/size".replace(
         "{layerId}",
         UrlBuilder.toString(params["layerId"])
@@ -116,7 +146,7 @@ export async function getDataCoverageSizeMap(
         headers
     };
 
-    return builder.request<string>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -129,7 +159,7 @@ export async function getDataCoverageSizeMap(
 export async function getDataCoverageSummary(
     builder: RequestBuilder,
     params: { layerId: string; version: string }
-): Promise<Size> {
+): Promise<LayerSummary> {
     const baseUrl = "/layers/{layerId}/summary".replace(
         "{layerId}",
         UrlBuilder.toString(params["layerId"])
@@ -144,7 +174,7 @@ export async function getDataCoverageSummary(
         headers
     };
 
-    return builder.request<Size>(urlBuilder, options);
+    return builder.request<LayerSummary>(urlBuilder, options);
 }
 
 /**
@@ -158,7 +188,7 @@ export async function getDataCoverageSummary(
 export async function getDataCoverageTile(
     builder: RequestBuilder,
     params: { layerId: string; datalevel: string }
-): Promise<string> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/tilemap".replace(
         "{layerId}",
         UrlBuilder.toString(params["layerId"])
@@ -173,7 +203,7 @@ export async function getDataCoverageTile(
         headers
     };
 
-    return builder.request<string>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -185,15 +215,16 @@ export async function getDataCoverageTile(
  */
 export async function getDataCoverageTimeMap(
     builder: RequestBuilder,
-    params: { layerId: string; datalevel: string }
-): Promise<string> {
-    const baseUrl = "/layers/{layerId}/heatmap/time".replace(
+    params: { layerId: string; datalevel: string; catalogHRN: string }
+): Promise<Response> {
+    const baseUrl = "/layers/{layerId}/heatmap/age".replace(
         "{layerId}",
         UrlBuilder.toString(params["layerId"])
     );
 
     const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
     urlBuilder.appendQuery("datalevel", params["datalevel"]);
+    urlBuilder.appendQuery("catalogHRN", params["catalogHRN"]);
 
     const headers: { [header: string]: string } = {};
     const options: RequestOptions = {
@@ -201,5 +232,5 @@ export async function getDataCoverageTimeMap(
         headers
     };
 
-    return builder.request<string>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }

--- a/@here/olp-sdk-dataservice-read/lib/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/CatalogClient.ts
@@ -113,7 +113,9 @@ export class CatalogClient {
      * @param layerName The name of the layer to look for.
      * @returns The promise with the layer object.
      */
-    public async getVolatileOrVersionedLayer(layerName: string): Promise<CatalogLayer> {
+    public async getVolatileOrVersionedLayer(
+        layerName: string
+    ): Promise<CatalogLayer> {
         const data = await this.findLayer(layerName);
         if (data === null) {
             return Promise.reject(
@@ -213,8 +215,7 @@ export class CatalogClient {
             return Promise.reject(
                 "Can't load layers from catalog configuration"
             );
-        };
-
+        }
 
         const layersConfigurations: ConfigApi.Layer[] =
             catalogConfiguration.layers;
@@ -260,7 +261,10 @@ export class CatalogClient {
         );
 
         for (const layerConfig of layersConfigurations) {
-            const layer: CatalogLayer | null = this.buildCatalogLayer(layerConfig, layerVersions.get(layerConfig.id));
+            const layer: CatalogLayer | null = this.buildCatalogLayer(
+                layerConfig,
+                layerVersions.get(layerConfig.id)
+            );
             if (layer) {
                 this.layers.set(layerConfig.id, layer);
             }
@@ -269,9 +273,15 @@ export class CatalogClient {
         return Promise.resolve({ ok: true });
     }
 
-    private buildCatalogLayer(config: ConfigApi.Layer, version?: number): CatalogLayer | null {
+    private buildCatalogLayer(
+        config: ConfigApi.Layer,
+        version?: number
+    ): CatalogLayer | null {
         // we're interesting only for versioned or volatile layers.
-        if (config.layerType !== "versioned" && config.layerType !== "volatile") {
+        if (
+            config.layerType !== "versioned" &&
+            config.layerType !== "volatile"
+        ) {
             return null;
         }
 
@@ -296,10 +306,11 @@ export class CatalogClient {
         const result: CatalogLayer = {
             ...config,
             apiVersion: 2,
-            downloadData: async (url: string, init?: RequestInit) => layerClient.downloadData(url, init),
-            getIndex: async(rootKey: QuadKey) => layerClient.getIndexMetadata(rootKey),
-            getPartition: async ( id: string, requestInit?: RequestInit) => layerClient.getPartition(id, requestInit),
-            getTile: async(quadKey: QuadKey, requestInit?: RequestInit) => layerClient.getTile(quadKey, requestInit),
+            getIndex: async (rootKey: QuadKey) =>
+                layerClient.getIndexMetadata(rootKey),
+            getPartition: async (id: string, requestInit?: RequestInit) =>
+                layerClient.getPartition(id, requestInit),
+            getTile: async (quadKey: QuadKey) => layerClient.getTile(quadKey),
             getPartitionsIndex: async () => layerClient.getPartitionsMetadata()
         };
 
@@ -307,10 +318,13 @@ export class CatalogClient {
         if (layerClient instanceof VersionLayerClient) {
             // make TS happy
             const versionedLayerClient = layerClient as VersionLayerClient;
-            result.getDataCoverageBitmap = async (requestInit?: RequestInit) => versionedLayerClient.getDataCoverageBitMap(requestInit);
-            result.getDataCoverageSizeMap = async (requestInit?: RequestInit) => versionedLayerClient.getDataCoverageSizeMap(requestInit);
-            result.getDataCoverageTimeMap = async (requestInit?: RequestInit) => versionedLayerClient.getDataCoverageTimeMap(requestInit);
-            result.getSummary = async (requestInit?: RequestInit) => versionedLayerClient.getSummary(requestInit);
+            result.getDataCoverageBitmap = async () =>
+                versionedLayerClient.getDataCoverageBitMap();
+            result.getDataCoverageSizeMap = async () =>
+                versionedLayerClient.getDataCoverageSizeMap();
+            result.getDataCoverageTimeMap = async () =>
+                versionedLayerClient.getDataCoverageTimeMap();
+            result.getSummary = async () => versionedLayerClient.getSummary();
         }
 
         return result;

--- a/@here/olp-sdk-dataservice-read/lib/CatalogLayer.ts
+++ b/@here/olp-sdk-dataservice-read/lib/CatalogLayer.ts
@@ -17,10 +17,13 @@
  * License-Filename: LICENSE
  */
 
-import { ConfigApi, MetadataApi } from "@here/olp-sdk-dataservice-api";
+import {
+    ConfigApi,
+    CoverageApi,
+    MetadataApi
+} from "@here/olp-sdk-dataservice-api";
 import { IndexMap } from "./CatalogClientCommon";
 import { QuadKey } from "./partitioning/QuadKey";
-import { LayerSummary } from "./VersionLayerClient";
 
 /**
  * @deprecated
@@ -66,14 +69,9 @@ export interface CatalogLayer extends ConfigApi.Layer {
      * ```
      *
      * @param quadKey The quad key of the tile.
-     * @param tileRequestInit Optional request options to be passed to fetch when downloading a
-     * tile.
      * @returns A promise of the HTTP response that contains the payload of the requested tile.
      */
-    getTile: (
-        quadKey: QuadKey,
-        tileRequestInit?: RequestInit | undefined
-    ) => Promise<Response>;
+    getTile: (quadKey: QuadKey) => Promise<Response>;
 
     /**
      * Asynchronously fetches a partition from this layer.
@@ -103,21 +101,13 @@ export interface CatalogLayer extends ConfigApi.Layer {
     getPartitionsIndex: () => Promise<MetadataApi.Partitions>;
 
     /**
-     * Downloads a URL, appending the credentials that this Layer is using.
-     *
-     * @param url The URL to download.
-     * @param init Optional extra parameters.
-     */
-    downloadData: (url: string, init?: RequestInit) => Promise<Response>;
-
-    /**
      * Asynchronously fetches data coverage bitmap of this layer.
      * @param RequestInit Optional request options to be passed to fetch when downloading a
      * coverage map.
      * @returns A promise of the http response that contains the payload of the requested coverage
      * map.
      */
-    getDataCoverageBitmap?: (requestInit?: RequestInit) => Promise<Blob>;
+    getDataCoverageBitmap?: (requestInit?: RequestInit) => Promise<Response>;
 
     /**
      * Asynchronously fetches data coverage size map of this layer.
@@ -126,7 +116,7 @@ export interface CatalogLayer extends ConfigApi.Layer {
      * @returns A promise of the http response that contains the payload of the requested coverage
      * map.
      */
-    getDataCoverageSizeMap?: (requestInit?: RequestInit) => Promise<Blob>;
+    getDataCoverageSizeMap?: (requestInit?: RequestInit) => Promise<Response>;
 
     /**
      * Asynchronously fetches data coverage time map of this layer.
@@ -135,7 +125,7 @@ export interface CatalogLayer extends ConfigApi.Layer {
      * @returns A promise of the http response that contains the payload of the requested coverage
      * map.
      */
-    getDataCoverageTimeMap?: (requestInit?: RequestInit) => Promise<Blob>;
+    getDataCoverageTimeMap?: (requestInit?: RequestInit) => Promise<Response>;
 
     /**
      * Asynchronously fetches summary data for this layer.
@@ -143,5 +133,7 @@ export interface CatalogLayer extends ConfigApi.Layer {
      * summary data.
      * @returns A promise of the http response that contains the summary data.
      */
-    getSummary?: (requestInit?: RequestInit) => Promise<LayerSummary>;
+    getSummary?: (
+        requestInit?: RequestInit
+    ) => Promise<CoverageApi.LayerSummary>;
 }

--- a/@here/olp-sdk-dataservice-read/lib/DataStoreClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/DataStoreClient.ts
@@ -61,14 +61,10 @@ export class DataStoreClient {
      * Get schema.
      *
      * @param schemaHrn String representing schema HRN.
-     * @param schemaRequestInit Optional request options to be passed to fetch when downloading
      * schema.
      * @returns Archive with schema.
      */
-    async getSchema(
-        schemaHrn: string,
-        schemaRequestInit?: RequestInit
-    ): Promise<ArrayBuffer> {
+    async getSchema(schemaHrn: string): Promise<ArrayBuffer> {
         const schemaDetails = await this.getSchemaDetails(schemaHrn);
         const schemaVariant = schemaDetails.variants!.find(
             variant => variant.id === "ds"
@@ -80,18 +76,17 @@ export class DataStoreClient {
         }
 
         const artifactBaseUrl = await this.context.getBaseUrl("artifact");
-        const schemaUrl = artifactBaseUrl + schemaVariant.url;
 
         const requestBuilder = new DataStoreRequestBuilder(
             this.context.dm,
-            "",
+            artifactBaseUrl,
             this.context.getToken
         );
-        const response = await requestBuilder
-            .downloadData(schemaUrl, schemaRequestInit)
-            .catch(() => {
-                throw new Error(`Cannot download Schema bundle: ${schemaHrn}`);
-            });
+        const response = await ArtifactApi.getArtifactUsingGET(requestBuilder, {
+            artifactHrn: schemaVariant.url
+        }).catch(() => {
+            throw new Error(`Cannot download Schema bundle: ${schemaHrn}`);
+        });
 
         if (response.status === 200) {
             return response.arrayBuffer();

--- a/@here/olp-sdk-dataservice-read/lib/DataStoreRequestBuilder.ts
+++ b/@here/olp-sdk-dataservice-read/lib/DataStoreRequestBuilder.ts
@@ -66,20 +66,15 @@ export class DataStoreRequestBuilder extends RequestBuilder {
         const options = await this.addBearerToken(init);
         return this.downloadManager
             .download(url, options)
-            .then(async response => {
-                if (response.ok) {
-                    return response.json();
-                }
-                throw new Error(JSON.stringify(response));
-            })
-            .catch(err => {
-                throw err;
-            });
+            .then(result => result.json())
+            .catch(err => Promise.reject(err));
     }
 
-    async downloadData(url: string, init?: RequestInit): Promise<Response> {
-        init = await this.addBearerToken(init);
-        return this.downloadManager.download(url, init);
+    async downloadBlob(url: string, init?: RequestInit): Promise<Response> {
+        const options = await this.addBearerToken(init);
+        return this.downloadManager
+            .download(url, options)
+            .catch(err => Promise.reject(err));
     }
 
     private async addBearerToken(init?: RequestInit): Promise<RequestInit> {

--- a/@here/olp-sdk-dataservice-read/lib/HypeDataProvider.ts
+++ b/@here/olp-sdk-dataservice-read/lib/HypeDataProvider.ts
@@ -101,16 +101,11 @@ export class HypeDataProvider {
         this.m_layer = layer;
     }
 
-    async getTile(
-        quadKey: QuadKey,
-        abortSignal?: AbortSignal | undefined
-    ): Promise<ArrayBufferLike> {
+    async getTile(quadKey: QuadKey): Promise<ArrayBufferLike> {
         if (this.m_layer === undefined || this.m_layer.getTile === undefined) {
             throw new Error(`Hype data provider not connected`);
         }
-        const response = await this.m_layer.getTile(quadKey, {
-            signal: abortSignal
-        });
+        const response = await this.m_layer.getTile(quadKey);
         if (!response.ok) {
             const errorMessage =
                 `Error downloading tile ${utils.mortonCodeFromQuadKey(

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -47,8 +47,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-dataservice-api": "0.9.0",
-    "@here/olp-sdk-fetch": "0.9.0"
+    "@here/olp-sdk-dataservice-api": "0.9.1",
+    "@here/olp-sdk-fetch": "0.9.1"
   },
   "devDependencies": {
     "@types/chai": "4.2.3",

--- a/@here/olp-sdk-dataservice-read/test/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/CatalogClient.test.ts
@@ -30,12 +30,15 @@ import { DataStoreContext } from "../lib/DataStoreContext";
 import { CatalogLayer } from "../lib/CatalogLayer";
 
 function createMockDownloadResponse(resp: Object) {
+    const headers = new Headers();
+    headers.append("etag", "1237696a7c876b7e");
+    headers.append("content-type", "application/json");
     const mock = {
         type: "aaa",
         status: 200,
         statusText: "success",
         ok: true,
-        headers: new Headers().append("etag", "1237696a7c876b7e"),
+        headers: headers,
         arrayBuffer: sinon.stub().returns(resp),
         json: sinon.stub().returns(resp),
         text: sinon.stub().returns(resp)
@@ -1984,8 +1987,10 @@ describe("CatalogClientOffline", () => {
     });
 
     it("#getLayerNonExisting", () => {
-        catalogClient.getVolatileOrVersionedLayer("NonExistingLayer").catch(err => {
-            assert.isDefined(err);
-        });
+        catalogClient
+            .getVolatileOrVersionedLayer("NonExistingLayer")
+            .catch(err => {
+                assert.isDefined(err);
+            });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@here/olp-sdk-dataservice-api@0.9.0":
+  version "0.9.0"
+  resolved "https://artifactory.in.here.com/artifactory/api/npm/here-node/@here/olp-sdk-dataservice-api/-/@here/here-olp-sdk-dataservice-api-0.9.0.tgz#81dba4d649e6598727b57952dbd9b84d51e63205"
+  integrity sha1-gduk1knmWYcntXlS29m4TVHmMgU=
+
+"@here/olp-sdk-fetch@0.9.0":
+  version "0.9.0"
+  resolved "https://artifactory.in.here.com/artifactory/api/npm/here-node/@here/olp-sdk-fetch/-/@here/here-olp-sdk-fetch-0.9.0.tgz#27da56bfa7d679ab71e900d03a5b385aad04851d"
+  integrity sha1-J9pWv6fWeatx6QDQOls4Wq0EhR0=
+  dependencies:
+    node-fetch "2.2.0"
+
 "@lerna/add@3.16.2":
   version "3.16.2"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.16.2.tgz#90ecc1be7051cfcec75496ce122f656295bd6e94"


### PR DESCRIPTION
Despite on datastore-api has methods to create URLs for downloading data, URLs were created with custom methods on the datastore-read side
To use correct API replace redundant methods for creating URLs to download data with propriate methods from @here/olp-sdk-datastore-api
Create method downloadBlob in requestBuilder to dowbload blob object data
Move LayerSummary interface to the coverage-api
Update tests

Resolves: OLPEDGE-822
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>