### PR TITLE
Create StatisticsClient class

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/coverage-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/coverage-api.ts
@@ -154,11 +154,10 @@ export async function getDataCoverageSizeMap(
  *
  * @summary Retrieve Layer size data for provided layer id and version
  * @param layerId Unique Layer Identifier
- * @param version Query passed to retrieve size of data in a specific Admin Area
  */
 export async function getDataCoverageSummary(
     builder: RequestBuilder,
-    params: { layerId: string; version: string }
+    params: { layerId: string }
 ): Promise<LayerSummary> {
     const baseUrl = "/layers/{layerId}/summary".replace(
         "{layerId}",
@@ -166,7 +165,6 @@ export async function getDataCoverageSummary(
     );
 
     const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
-    urlBuilder.appendQuery("version", params["version"]);
 
     const headers: { [header: string]: string } = {};
     const options: RequestOptions = {

--- a/@here/olp-sdk-dataservice-read/index.ts
+++ b/@here/olp-sdk-dataservice-read/index.ts
@@ -30,5 +30,7 @@ export * from "./lib/partitioning/QuadKey";
 export * from "./lib/partitioning/QuadKeyUtils";
 export * from "./lib/DownloadManager";
 export * from "./lib/DataStoreContext";
+export * from "./lib/StatisticsClient";
+export * from "./lib/SummaryRequest";
 export * from "./lib/VersionLayerClient";
 export * from "./lib/VolatileLayerClient";

--- a/@here/olp-sdk-dataservice-read/lib/StatisticsClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/StatisticsClient.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { CoverageApi } from "@here/olp-sdk-dataservice-api";
+import { ErrorHTTPResponse } from "./CatalogClientCommon";
+import { DataStoreContext } from "./DataStoreContext";
+import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
+import { SummaryRequest } from "./SummaryRequest";
+
+/**
+ * A class that provides possibility to get Statistic Metadata and Data for Versioned layer
+ */
+export class StatisticsClient {
+    constructor(private readonly context: DataStoreContext) {}
+
+    /**
+     * Fetch and return layer summary from the Statistics service.
+     *
+     * @param summaryRequest Options which are needed to fetch summary.
+     * Includes @catalogHrn and @layerId
+     *
+     * @returns A promise with the layer summary.
+     */
+    async getSummary(summaryRequest: SummaryRequest): Promise<CoverageApi.LayerSummary> {
+        const layerId = summaryRequest.getLayerId();
+        const catalogHrn = summaryRequest.getCatalogHrn();
+
+        if (catalogHrn === undefined) {
+            return Promise.reject(new Error(`No catalogHrn provided`));
+        }
+        if (layerId === undefined) {
+            return Promise.reject(new Error(`No layerId provided`));
+        }
+        const coverageRequestBuilder = await this.getRequestBuilder(catalogHrn)
+            .catch(error => Promise.reject(new Error(error)));
+        return CoverageApi.getDataCoverageSummary(coverageRequestBuilder, {
+            layerId
+        }).catch(this.errorHandler);
+    }
+
+    private async errorHandler(error: Response) {
+        return Promise.reject(
+            new Error(
+                `Statistic Service error: HTTP ${error.status}, ${error.statusText || ""}`
+            )
+        );
+    }
+
+    private async getRequestBuilder(hrn: string): Promise<DataStoreRequestBuilder> {
+        const url = await this.context
+            .getBaseUrl("statistics", hrn)
+            .catch(err =>
+                Promise.reject(
+                    `Error retrieving from cache builder for resource "${hrn}" and api: Statistic".\n${err}"`
+                )
+            );
+        return new DataStoreRequestBuilder(
+            this.context.dm,
+            url,
+            this.context.getToken
+        );
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/SummaryRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/SummaryRequest.ts
@@ -17,17 +17,30 @@
  * License-Filename: LICENSE
  */
 
-export * from "./lib/DataStoreClient";
-export * from "./lib/CatalogClient";
-export * from "./lib/HRN";
-export * from "./lib/HypeDataProvider";
-export * from "./lib/CatalogClientCommon";
-export * from "./lib/error/NotFoundError";
-export * from "./lib/partitioning/QuadKey";
-export * from "./lib/partitioning/QuadKeyUtils";
-export * from "./lib/DownloadManager";
-export * from "./lib/DataStoreContext";
-export * from "./lib/StatisticsClient";
-export * from "./lib/SummaryRequest";
-export * from "./lib/VersionLayerClient";
-export * from "./lib/VolatileLayerClient";
+/**
+ * A class that prepare information for calls to get Statistics from CoverageAPI
+ */
+export class SummaryRequest {
+    private catalogHrn: string | undefined;
+    private layerId: string | undefined;
+
+    constructor() {}
+
+    public getCatalogHrn(): string | undefined {
+        return this.catalogHrn;
+    }
+
+    public getLayerId(): string | undefined {
+        return this.layerId;
+    }
+
+    public withCatalogHrn(hrn: string) {
+        this.catalogHrn = hrn;
+        return this;
+    }
+
+    public withLayerId(layerId: string) {
+        this.layerId = layerId;
+        return this;
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/VersionLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/VersionLayerClient.ts
@@ -323,10 +323,9 @@ export class VersionLayerClient {
         const coverageRequestBuilder = await this.getRequestBuilder(
             "statistics"
         );
-        return CoverageApi.getDataCoverageSummary(coverageRequestBuilder, {
-            layerId: this.layerId,
-            version: `${this.version}`
-        }).catch(this.errorHandler);
+        return CoverageApi
+            .getDataCoverageSummary(coverageRequestBuilder, {layerId: this.layerId})
+            .catch(this.errorHandler);
     }
 
     private async errorHandler(error: any) {

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { StatisticsClient, SummaryRequest } from "@here/olp-sdk-dataservice-read";
+import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
+import { CoverageApi } from "@here/olp-sdk-dataservice-api";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("StatistiscClient", () => {
+    let sandbox: sinon.SinonSandbox;
+    let getDataCoverageSummaryStub: any;
+    const mockedHRN = "hrn:::mocked-hrn";
+    const mockedLayerId = "mocked-layed-id";
+    const fakeURL = "http://fake-base.url";
+
+    class MockedDataStoreContext {
+        constructor() {}
+
+        public async getBaseUrl() {
+            return Promise.resolve(fakeURL);
+        }
+    }
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    beforeEach(() => {
+        sandbox
+            .stub(dataServiceRead, "DataStoreContext")
+            .callsFake(() => new MockedDataStoreContext());
+        getDataCoverageSummaryStub = sandbox.stub(CoverageApi, "getDataCoverageSummary");
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("Shoud be initialised with context", async () => {
+        const context = new MockedDataStoreContext();
+        const statisticsClient = new StatisticsClient(
+            (context as unknown) as dataServiceRead.DataStoreContext
+        );
+        assert.isDefined(statisticsClient);
+    });
+
+    it("Should method getSummary provide data", async () => {
+        const mockedSummary: CoverageApi.LayerSummary = {
+            catalogHRN: mockedHRN,
+            layer: mockedLayerId,
+            levelSummary: {
+                "1": {
+                    size: 12121122,
+                    processedTimestamp: 12312132135,
+                    maxPartitionSize: 42,
+                    centroid: 4201,
+                    totalPartitions: 2000,
+                    version: 42,
+                    minPartitionSize: 1,
+                    boundingBox: {
+                        east: 1,
+                        north: 2,
+                        south: 3,
+                        west: 4
+                    }
+                }
+            }
+        };
+        const context = new MockedDataStoreContext();
+        const statisticsClient = new StatisticsClient(
+            (context as unknown) as dataServiceRead.DataStoreContext
+        );
+        assert.isDefined(statisticsClient);
+        getDataCoverageSummaryStub.callsFake((builder: any, params: any): Promise<CoverageApi.LayerSummary> => {
+            return Promise.resolve(mockedSummary);
+        });
+
+        const summaryRequest = new SummaryRequest()
+            .withCatalogHrn(mockedHRN)
+            .withLayerId(mockedLayerId);
+
+        const summary = await statisticsClient.getSummary(summaryRequest);
+        assert.isDefined(summary);
+    });
+});

--- a/@here/olp-sdk-dataservice-read/test/unit/SummaryRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SummaryRequest.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { SummaryRequest } from "@here/olp-sdk-dataservice-read";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("SummaryRequest", () => {
+    const mockedHRN = "hrn:::mocked-hrn";
+    const mockedLayerId = "mocked-layed-id"
+
+    it("Should initialize", () => {
+        const summaryRequest = new SummaryRequest();
+
+        assert.isDefined(summaryRequest);
+        expect(summaryRequest).be.instanceOf(SummaryRequest);
+    });
+
+    it("Should set parameters", () => {
+        const summaryRequest = new SummaryRequest();
+        const summaryRequestWithCatalogHrn = summaryRequest.withCatalogHrn(mockedHRN);
+        const summaryRequestWithLAyerId = summaryRequest.withLayerId(mockedLayerId);
+
+        expect(summaryRequestWithCatalogHrn.getCatalogHrn()).to.be.equal(mockedHRN);
+        expect(summaryRequestWithLAyerId.getLayerId()).to.be.equal(mockedLayerId);
+    });
+
+    it("Should get parameters with chain", () => {
+        const summaryRequest = new SummaryRequest()
+            .withCatalogHrn(mockedHRN)
+            .withLayerId(mockedLayerId);
+
+        expect(summaryRequest.getCatalogHrn()).to.be.equal(mockedHRN);
+        expect(summaryRequest.getLayerId()).to.be.equal(mockedLayerId);
+    });
+});


### PR DESCRIPTION
Create StatisticsClient class, add constructor and unit-tests
Add getSummary method to fetch summary data from CoverageApi
Create SummaryRequest class to add parameters to the getSummary method

Resolves: OLPEDGE-939, OLPEDGE-940
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>