### PR TITLE
Rename VersionLayerClient to VersionedLayerClient

### DIFF
--- a/@here/olp-sdk-dataservice-read/index.ts
+++ b/@here/olp-sdk-dataservice-read/index.ts
@@ -33,5 +33,5 @@ export * from "./lib/DataStoreContext";
 export * from "./lib/StatisticsClient";
 export * from "./lib/StatisticsRequest";
 export * from "./lib/SummaryRequest";
-export * from "./lib/VersionLayerClient";
+export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";

--- a/@here/olp-sdk-dataservice-read/index.web.ts
+++ b/@here/olp-sdk-dataservice-read/index.web.ts
@@ -30,5 +30,5 @@ export * from "./lib/DataStoreContext";
 export * from "./lib/StatisticsClient";
 export * from "./lib/StatisticsRequest";
 export * from "./lib/SummaryRequest";
-export * from "./lib/VersionLayerClient";
+export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";

--- a/@here/olp-sdk-dataservice-read/webpack.config.js
+++ b/@here/olp-sdk-dataservice-read/webpack.config.js
@@ -5,13 +5,12 @@ module.exports = env => {
   const isProd = env.NODE_ENV === "production";
 
   return {
-    target: "web",
     mode: env.NODE_ENV,
-    devtool: isProd ? undefined : "inline-source-map",
+    devtool: isProd ? undefined : "source-map",
     resolve: {
       extensions: [".ts", ".js"]
     },
-    entry: "./index.web.ts",
+    entry: "./index.ts",
     output: {
       filename: `olp-sdk-dataservice-read${isProd ? '.min' : '.dev'}.js`,
       path: path.resolve(__dirname, `dist`),
@@ -29,6 +28,9 @@ module.exports = env => {
           }
         }
       ]
-    }
+    },
+    node: {
+        fs: 'empty'
+      }
   };
 };


### PR DESCRIPTION
Rename  VersionLayerClient to VersionedLayerClient.
Performed rename VersionLayerClient to VersionedLayerClient.

Relates-To: OLPEDGE-904

Signed-off-by: Bautista, Iryna ext-iryna.bautista@here.com