### PR TITLE
Rename VersionLayerClient to VersionedLayerClient.

### DIFF
--- a/@here/olp-sdk-dataservice-read/index.ts
+++ b/@here/olp-sdk-dataservice-read/index.ts
@@ -33,5 +33,5 @@ export * from "./lib/DataStoreContext";
 export * from "./lib/StatisticsClient";
 export * from "./lib/StatisticsRequest";
 export * from "./lib/SummaryRequest";
-export * from "./lib/VersionLayerClient";
+export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";

--- a/@here/olp-sdk-dataservice-read/index.web.ts
+++ b/@here/olp-sdk-dataservice-read/index.web.ts
@@ -30,5 +30,5 @@ export * from "./lib/DataStoreContext";
 export * from "./lib/StatisticsClient";
 export * from "./lib/StatisticsRequest";
 export * from "./lib/SummaryRequest";
-export * from "./lib/VersionLayerClient";
+export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";

--- a/@here/olp-sdk-dataservice-read/lib/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/CatalogClient.ts
@@ -23,7 +23,7 @@ import { DataStoreContext } from "./DataStoreContext";
 import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
 import { HRN } from "./HRN";
 import { QuadKey } from "./partitioning/QuadKey";
-import { VersionLayerClient } from "./VersionLayerClient";
+import { VersionedLayerClient } from "./VersionedLayerClient";
 import { VolatileLayerClient } from "./VolatileLayerClient";
 
 /**
@@ -291,10 +291,10 @@ export class CatalogClient {
             return null;
         }
 
-        let layerClient: VersionLayerClient | VolatileLayerClient;
+        let layerClient: VersionedLayerClient | VolatileLayerClient;
 
         if (config.layerType === "versioned") {
-            layerClient = new VersionLayerClient(
+            layerClient = new VersionedLayerClient(
                 HRN.fromString(this.hrn),
                 config.id,
                 this.context
@@ -321,9 +321,9 @@ export class CatalogClient {
         };
 
         // add not required methods for interface, but required for version layer,
-        if (layerClient instanceof VersionLayerClient) {
+        if (layerClient instanceof VersionedLayerClient) {
             // make TS happy
-            const versionedLayerClient = layerClient as VersionLayerClient;
+            const versionedLayerClient = layerClient as VersionedLayerClient;
             result.getDataCoverageBitmap = async () =>
                 versionedLayerClient.getDataCoverageBitMap();
             result.getDataCoverageSizeMap = async () =>

--- a/@here/olp-sdk-dataservice-read/lib/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/VersionedLayerClient.ts
@@ -40,7 +40,7 @@ import * as utils from "./partitioning/QuadKeyUtils";
  * A class that describes versioned layer
  * and provides possibility to get layer Metadata and Partitions.
  */
-export class VersionLayerClient {
+export class VersionedLayerClient {
     readonly hrn: string;
     readonly layerId: string;
     readonly context: DataStoreContext;
@@ -129,7 +129,7 @@ export class VersionLayerClient {
      * Example:
      *
      * ```typescript
-     * const response = versionLayerClient.getTile(tileKey);
+     * const response = versionedLayerClient.getTile(tileKey);
      * if (!response.ok) {
      *     // a network error happened
      *     console.error("Unable to download tile", response.statusText);
@@ -393,8 +393,8 @@ export class VersionLayerClient {
         indexRootKey: QuadKey,
         dsIndex: QueryApi.Index
     ): IndexMap {
-        const subkeyAddFunction = VersionLayerClient.subkeyAddFunction();
-        const toTileKeyFunction = VersionLayerClient.toTileKeyFunction();
+        const subkeyAddFunction = VersionedLayerClient.subkeyAddFunction();
+        const toTileKeyFunction = VersionedLayerClient.toTileKeyFunction();
 
         const subQuads = new Map<number, string>();
 

--- a/@here/olp-sdk-dataservice-read/test/CatalogClientMock.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/CatalogClientMock.test.ts
@@ -11,7 +11,7 @@ import { ConfigApi } from "@here/olp-sdk-dataservice-api/";
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe("VersionLayerClientMockTests", () => {
+describe("VersionedLayerClientMockTests", () => {
     let latestVersionStub: sinon.SinonStub;
 
     let dataStoreContextStubInstance = sinon.createStubInstance(

--- a/@here/olp-sdk-dataservice-read/test/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/VersionedLayerClient.test.ts
@@ -25,7 +25,7 @@ import { DataStoreContext } from "../lib/DataStoreContext";
 import { DataStoreDownloadManager } from "../lib/DataStoreDownloadManager";
 import { DownloadManager } from "../lib/DownloadManager";
 import { HRN } from "../lib/HRN";
-import { VersionLayerClient } from "../lib/VersionLayerClient";
+import { VersionedLayerClient } from "../lib/VersionedLayerClient";
 
 function createMockDownloadResponse(resp: Object, blob?: string) {
     const headers = new Headers();
@@ -534,10 +534,10 @@ function createMockDownloadManager(): DownloadManager {
     return downloadMgr as any;
 }
 
-// versionLayerClient
+// VersionedLayerClient Tests
 
-describe("VersionLayerClient", () => {
-    let versionLayerClient: VersionLayerClient;
+describe("VersionedLayerClient", () => {
+    let versionedLayerClient: VersionedLayerClient;
 
     before(async () => {
         const testHRN =
@@ -551,16 +551,16 @@ describe("VersionLayerClient", () => {
         });
 
         assert.isNotNull(context);
-        versionLayerClient = await new VersionLayerClient(
+        versionedLayerClient = await new VersionedLayerClient(
             HRN.fromString(testHRN),
             "protobuf-example-berlin-v1",
             context
         );
-        assert.isNotNull(versionLayerClient);
+        assert.isNotNull(versionedLayerClient);
     });
 
     it("#getPartition", async () => {
-        let response = await versionLayerClient.getPartition("23618173");
+        let response = await versionedLayerClient.getPartition("23618173");
         assert.isNotNull(response);
 
         let buf = await response.text();
@@ -568,7 +568,7 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getDataCoverageBitmap", async () => {
-        let response = await versionLayerClient.getDataCoverageBitMap();
+        let response = await versionedLayerClient.getDataCoverageBitMap();
         assert.isNotNull(response);
 
         let buf = await response.text();
@@ -576,7 +576,7 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getDataCoverageSizeMap", async () => {
-        let response = await versionLayerClient.getDataCoverageSizeMap();
+        let response = await versionedLayerClient.getDataCoverageSizeMap();
         assert.isNotNull(response);
 
         let buf = await response.text();
@@ -584,7 +584,7 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getDataCoverageTimeMap", async () => {
-        let response = await versionLayerClient.getDataCoverageTimeMap();
+        let response = await versionedLayerClient.getDataCoverageTimeMap();
         assert.isNotNull(response);
 
         let buf = await response.text();
@@ -592,12 +592,12 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getSummary", async () => {
-        let response = await versionLayerClient.getSummary();
+        let response = await versionedLayerClient.getSummary();
         assert.isNotNull(response);
     });
 
     it("#getTile", async () => {
-        let response = await versionLayerClient.getTile(
+        let response = await versionedLayerClient.getTile(
             utils.quadKeyFromMortonCode("1476147")
         );
         assert.isNotNull(response);
@@ -609,8 +609,8 @@ describe("VersionLayerClient", () => {
 
     it("#getTiles", async () => {
         const results = await Promise.all([
-            versionLayerClient.getTile(utils.quadKeyFromMortonCode("1476147")),
-            versionLayerClient.getTile(utils.quadKeyFromMortonCode("1476147"))
+            versionedLayerClient.getTile(utils.quadKeyFromMortonCode("1476147")),
+            versionedLayerClient.getTile(utils.quadKeyFromMortonCode("1476147"))
         ]);
 
         const contents = await Promise.all([
@@ -622,7 +622,7 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getMissingTile", async () => {
-        let response = await versionLayerClient.getTile(
+        let response = await versionedLayerClient.getTile(
             utils.quadKeyFromMortonCode("0000")
         );
         assert.isNotNull(response);
@@ -632,7 +632,7 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getTileWithETag", async () => {
-        const response = await versionLayerClient.getTile(
+        const response = await versionedLayerClient.getTile(
             utils.quadKeyFromMortonCode("1476147")
         );
         assert.isNotNull(response);
@@ -647,7 +647,7 @@ describe("VersionLayerClient", () => {
         assert.strictEqual(buf, "DT_1_1001");
 
         // fetch again, this time with etag
-        const cachedResponse = await versionLayerClient.getTile(
+        const cachedResponse = await versionedLayerClient.getTile(
             utils.quadKeyFromMortonCode("23618359")
         );
         // make sure status is 304 - not modified
@@ -657,7 +657,7 @@ describe("VersionLayerClient", () => {
     it("#abortGetPartition", async () => {
         const abortController = new AbortController();
         const init = { signal: abortController.signal };
-        const responsePromise = await versionLayerClient.getPartition(
+        const responsePromise = await versionedLayerClient.getPartition(
             "23618173",
             init
         );
@@ -672,14 +672,14 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getAggregatedTile", async () => {
-        const response = await versionLayerClient.getTile(
+        const response = await versionedLayerClient.getTile(
             utils.quadKeyFromMortonCode("5904591")
         );
         assert.strictEqual(response.status, 204);
 
         // try a direct ancestor
         {
-            const aggregatedResponse = await versionLayerClient.getAggregatedTile(
+            const aggregatedResponse = await versionedLayerClient.getAggregatedTile(
                 utils.quadKeyFromMortonCode("5904591")
             );
             assert.isTrue(aggregatedResponse.ok);
@@ -694,13 +694,13 @@ describe("VersionLayerClient", () => {
     });
 
     it("#getPartitionsMetadata", async () => {
-        const paritions = await versionLayerClient.getPartitionsMetadata();
+        const paritions = await versionedLayerClient.getPartitionsMetadata();
         assert.isDefined(paritions);
         assert.isAbove(paritions.partitions.length, 0, "index is empty");
     });
 
     it("#getIndexMetadata", async () => {
-        let index = await versionLayerClient.getIndexMetadata(
+        let index = await versionedLayerClient.getIndexMetadata(
             utils.quadKeyFromMortonCode("23618359")
         );
         assert.isDefined(index);

--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -8,7 +8,7 @@ OLP SDK for TypeScript includes core components for accessing OLP APIs from any 
 - [Getting Credentials](#credentials)
 - [Available Components](#components)
 - [Context and CatalogClient](#context-catalog)
-- [VersionLayerClient example](#examples)
+- [VersionedLayerClient example](#examples)
 
 ## <a name="prerequisite"></a> OLP Prerequisite Knowledge
 

--- a/docs/examples/nodejs-read-versioned-layer.md
+++ b/docs/examples/nodejs-read-versioned-layer.md
@@ -115,16 +115,16 @@ const context = new DataStoreContext({
 
 ```
 
-## VersionLayerClient
+## VersionedLayerClient
 
 Therefore, when you have context, you can get catalog clients for different catalogs and read the information.
 You can get more information about Version Layer following the [link](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/publishing-data-versioned.html).
-To create VersionLayerClient, run:
+To create VersionedLayerClient, run:
 
 
 ```typescript
 import { UserAuth } from "@here/olp-sdk-authentification";
-import { DataStoreContext, VersionLayerClient } from "@here/olp-sdk-dataservice-read";
+import { DataStoreContext, VersionedLayerClient } from "@here/olp-sdk-dataservice-read";
 import * as utils from "@here/olp-sdk-dataservice-read";
 
 const userAuth = new UserAuth({
@@ -141,7 +141,7 @@ const context = new DataStoreContext({
 });
 
 //  Client for "protobuf-example-berlin-v1" layer from "sensor-data-sensoris-versioned-example" catalog
-const versionClient = await new VersionLayerClient({
+const versionClient = await new VersionedLayerClient({
     context,
     hrn: "hrn:here:data:::sensor-data-sensoris-versioned-example",
     layerId: "protobuf-example-berlin-v1",


### PR DESCRIPTION
* Rename class VersionLayerClient to VersionedLayerClient.

* Update imports, tests and variables.

Relates-To: OLPEDGE-904.

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>