### PR TITLE
Remove statistics related code from VersionedLayer.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/CatalogClient.ts
@@ -320,19 +320,6 @@ export class CatalogClient {
             getPartitionsIndex: async () => layerClient.getPartitionsMetadata()
         };
 
-        // add not required methods for interface, but required for version layer,
-        if (layerClient instanceof VersionedLayerClient) {
-            // make TS happy
-            const versionedLayerClient = layerClient as VersionedLayerClient;
-            result.getDataCoverageBitmap = async () =>
-                versionedLayerClient.getDataCoverageBitMap();
-            result.getDataCoverageSizeMap = async () =>
-                versionedLayerClient.getDataCoverageSizeMap();
-            result.getDataCoverageTimeMap = async () =>
-                versionedLayerClient.getDataCoverageTimeMap();
-            result.getSummary = async () => versionedLayerClient.getSummary();
-        }
-
         return result;
     }
 }

--- a/@here/olp-sdk-dataservice-read/lib/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/VersionedLayerClient.ts
@@ -25,12 +25,7 @@ import {
 import { ApiName, DataStoreContext } from "./DataStoreContext";
 import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
 
-import {
-    BlobApi,
-    CoverageApi,
-    MetadataApi,
-    QueryApi
-} from "@here/olp-sdk-dataservice-api";
+import { BlobApi, MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
 import { HRN } from "./HRN";
 import { LRUCache } from "./LRUCache";
 import { QuadKey } from "./partitioning/QuadKey";
@@ -226,80 +221,6 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Fetch and return data coverage bitmap for the specified layer and version.
-     *
-     * @param requestInit Optional request options to be passed to fetch when downloading
-     * the coverage map.
-     *
-     *  @returns A promise with the payload of the requested bitmap.
-     */
-    async getDataCoverageBitMap(): Promise<Response> {
-        const coverageRequestBuilder = await this.getRequestBuilder(
-            "statistics"
-        );
-        return CoverageApi.getDataCoverageTile(coverageRequestBuilder, {
-            layerId: this.layerId,
-            // @todo datalevel is hardcoded. It is known issue, ticket about API bug is created
-            datalevel: "12"
-        }).catch(this.errorHandler);
-    }
-
-    /**
-     * Fetch and return data coverage bitmap for the specified layer and version.
-     *
-     * @param requestInit Optional request options to be passed to fetch when downloading
-     * the coverage map.
-     *
-     *  @returns A promise with the payload of the requested size map.
-     */
-    async getDataCoverageSizeMap(): Promise<Response> {
-        const coverageRequestBuilder = await this.getRequestBuilder(
-            "statistics"
-        );
-        return CoverageApi.getDataCoverageSizeMap(coverageRequestBuilder, {
-            layerId: this.layerId,
-            // @todo datalevel is hardcoded. It is known issue, ticket about API bug is created
-            datalevel: "12"
-        }).catch(this.errorHandler);
-    }
-
-    /**
-     * Fetch and return data coverage time map for the specified layer and version.
-     *
-     * @param requestInit Optional request options to be passed to fetch when downloading
-     * the coverage map.
-     *
-     *  @returns A promise with the payload of the requested time map.
-     */
-    async getDataCoverageTimeMap(): Promise<Response> {
-        const coverageRequestBuilder = await this.getRequestBuilder(
-            "statistics"
-        );
-        return CoverageApi.getDataCoverageTimeMap(coverageRequestBuilder, {
-            layerId: this.layerId,
-            // @todo datalevel is hardcoded. It is known issue, ticket about API bug is created
-            datalevel: "12",
-            catalogHRN: this.hrn
-        }).catch(this.errorHandler);
-    }
-
-    /**
-     * Fetch and return layer summary from the Statistics service.
-     *
-     * @param requestInit Optional request options to be passed to fetch when downloading summary.
-     *
-     * @returns A promise with the layer summary.
-     */
-    async getSummary(): Promise<CoverageApi.LayerSummary> {
-        const coverageRequestBuilder = await this.getRequestBuilder(
-            "statistics"
-        );
-        return CoverageApi.getDataCoverageSummary(coverageRequestBuilder, {
-            layerId: this.layerId
-        }).catch(this.errorHandler);
-    }
-
-    /**
      * Gets the latest available catalog version what can be used as latest layer version
      */
     private async getLatestVersion(): Promise<MetadataApi.VersionResponse> {
@@ -315,18 +236,6 @@ export class VersionedLayerClient {
                         error.status
                     }, ${error.statusText || ""}`
                 )
-            )
-        );
-    }
-
-    private async errorHandler(error: any) {
-        return Promise.reject(
-            new ErrorHTTPResponse(
-                `Statistic Service error: HTTP ${
-                    error.status
-                }, ${error.statusText || error.cause || ""}` +
-                    `\n${error.action || ""}`,
-                error
             )
         );
     }

--- a/@here/olp-sdk-dataservice-read/test/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/VersionedLayerClient.test.ts
@@ -337,21 +337,6 @@ urlToResponses.set(
 const headersMock = new Headers();
 headersMock.append("etag", "1237696a7c876b7e");
 
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/tilemap?datalevel=12",
-    "DT_1_1010"
-);
-
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/heatmap/size?datalevel=12",
-    createMockDownloadResponse("DT_1_1010", "image/jpeg")
-);
-
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/heatmap/age?datalevel=12&catalogHRN=hrn%3Ahere%3Adata%3A%3A%3Asensor-data-sensoris-versioned-example",
-    createMockDownloadResponse("DT_1_1010", "image/jpeg")
-);
-
 // NewversionLayerClientOffline - blob
 urlToResponses.set(
     "https://blob.data.api.platform.here.com/blobstore/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/data/c9116bb9-7d00-44bf-9b26-b4ab4c274665",
@@ -408,88 +393,6 @@ urlToResponses.set(
         arrayBuffer: sinon.stub(),
         json: sinon.stub().returns(""),
         text: sinon.stub().returns("")
-    }
-);
-
-// NewversionLayerClientOffline #getDataCoverageBitmap
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/tilemap",
-    {
-        type: "aaa",
-        status: 200,
-        statusText: "success",
-        ok: true,
-        headers: headersMock,
-        arrayBuffer: sinon.stub(),
-        blob: sinon.stub().returns("heatmap-tillemap-blob")
-    }
-);
-
-// NewversionLayerClientOffline #getDataCoverageSizeMap
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/heatmap/size",
-    {
-        type: "aaa",
-        status: 200,
-        statusText: "success",
-        ok: true,
-        headers: headersMock,
-        arrayBuffer: sinon.stub(),
-        blob: sinon.stub().returns("heatmap-size-blob")
-    }
-);
-
-// NewversionLayerClientOffline #getDataCoverageTimeMap
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/heatmap/age",
-    {
-        type: "aaa",
-        status: 200,
-        statusText: "success",
-        ok: true,
-        headers: headersMock,
-        arrayBuffer: sinon.stub(),
-        blob: sinon.stub().returns("heatmap-age-blob")
-    }
-);
-
-// NewversionLayerClientOffline #getSummary
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/summary",
-    {
-        type: "aaa",
-        status: 200,
-        statusText: "success",
-        ok: true,
-        headers: headersMock,
-        arrayBuffer: sinon.stub(),
-        json: sinon.stub().returns("summary"),
-        text: sinon.stub().returns("summary")
-    }
-);
-
-urlToResponses.set(
-    "https://statistics.data.api.platform.here.com/statistics/v1/catalogs/hrn:here:data:::sensor-data-sensoris-versioned-example/layers/protobuf-example-berlin-v1/summary?version=0",
-    {
-        catalogHRN: "hrn:here:data:::sensor-data-sensoris-versioned-example",
-        layer: "protobuf-example-berlin-v1",
-        levelSummary: {
-            "12": {
-                boundingBox: {
-                    east: 14.23828125,
-                    south: 52.03125,
-                    north: 52.822265625,
-                    west: 12.568359375
-                },
-                size: 255967186,
-                processedTimestamp: 1556973621446,
-                centroid: 23618400,
-                minPartitionSize: 128854,
-                maxPartitionSize: 18162544,
-                version: 0,
-                totalPartitions: 161
-            }
-        }
     }
 );
 
@@ -567,35 +470,6 @@ describe("VersionedLayerClient", () => {
         assert.strictEqual(buf, "DT_1_1010");
     });
 
-    it("#getDataCoverageBitmap", async () => {
-        let response = await versionedLayerClient.getDataCoverageBitMap();
-        assert.isNotNull(response);
-
-        let buf = await response.text();
-        assert.strictEqual(buf, "DT_1_1010");
-    });
-
-    it("#getDataCoverageSizeMap", async () => {
-        let response = await versionedLayerClient.getDataCoverageSizeMap();
-        assert.isNotNull(response);
-
-        let buf = await response.text();
-        assert.strictEqual(buf, "DT_1_1010");
-    });
-
-    it("#getDataCoverageTimeMap", async () => {
-        let response = await versionedLayerClient.getDataCoverageTimeMap();
-        assert.isNotNull(response);
-
-        let buf = await response.text();
-        assert.strictEqual(buf, "DT_1_1010");
-    });
-
-    it("#getSummary", async () => {
-        let response = await versionedLayerClient.getSummary();
-        assert.isNotNull(response);
-    });
-
     it("#getTile", async () => {
         let response = await versionedLayerClient.getTile(
             utils.quadKeyFromMortonCode("1476147")
@@ -609,7 +483,9 @@ describe("VersionedLayerClient", () => {
 
     it("#getTiles", async () => {
         const results = await Promise.all([
-            versionedLayerClient.getTile(utils.quadKeyFromMortonCode("1476147")),
+            versionedLayerClient.getTile(
+                utils.quadKeyFromMortonCode("1476147")
+            ),
             versionedLayerClient.getTile(utils.quadKeyFromMortonCode("1476147"))
         ]);
 


### PR DESCRIPTION
* As now we have new StatisticsClient class, removed statistics related methods of VersionedLayerClient: getSumary, getDataCoverageTimeMap, getDataCoverageSizeMap, getDataCoverageBitmap.

* Remove related unit tests for VersionedLayerClient.

Relates-To: OLPEDGE-960

Signed-off-by: Bautista, Iryna ext-iryna.bautista@here.com