### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug.
+
+### Which version/tag/hash of the HERE OLP SDK are you using?
+
+### What TypeScript version are you using to compile?
+
+### Are you using node.js or browser? What type/version?
+
+### Steps to reproduce the issue.
+
+### Expected behavior.
+
+### Can you provide any TRACE level logs?
+*Please strip sensitive data prior to upload!*


### PR DESCRIPTION
Adds an issue template to the repository to be used by github as a base when users want to report an issue with the SDK.

Relates-to: OLPEDGE-1011