### PR TITLE
Move catalogs related code from DataStoreClient to ConfigClient.

### DIFF
--- a/@here/olp-sdk-dataservice-read/index.ts
+++ b/@here/olp-sdk-dataservice-read/index.ts
@@ -34,3 +34,5 @@ export * from "./lib/StatisticsRequest";
 export * from "./lib/SummaryRequest";
 export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";
+export * from "./lib/ConfigClient";
+export * from "./lib/CatalogsRequest";

--- a/@here/olp-sdk-dataservice-read/index.web.ts
+++ b/@here/olp-sdk-dataservice-read/index.web.ts
@@ -31,3 +31,5 @@ export * from "./lib/StatisticsRequest";
 export * from "./lib/SummaryRequest";
 export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";
+export * from "./lib/ConfigClient";
+export * from "./lib/CatalogsRequest";

--- a/@here/olp-sdk-dataservice-read/lib/CatalogsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/CatalogsRequest.ts
@@ -1,0 +1,21 @@
+/**
+ * A class that prepare information for calls to getCatalogs from ConfigAPI.
+ */
+export class CatalogsRequest {
+    private schemaHrn: string | undefined;
+
+    public getSchema(): string | undefined {
+        return this.schemaHrn;
+    }
+
+    /**
+     * Set value of layer schema HRN to use in method getCatalogs from ConfigClient.
+     * If schema is setted, then getCatalogs will return filtered response by the specified layer schema HRN.
+     * If schema is not setted, then filter will return search for all.
+     * @param schemaHrn layer schema HRN
+     */
+    public withSchema(schemaHrn: string): CatalogsRequest {
+        this.schemaHrn = schemaHrn;
+        return this;
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/ConfigClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/ConfigClient.ts
@@ -1,0 +1,36 @@
+import { ConfigApi } from "@here/olp-sdk-dataservice-api";
+import { CatalogsRequest } from "./CatalogsRequest";
+import { DataStoreContext } from "./DataStoreContext";
+import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
+
+export class ConfigClient {
+    /**
+     * Constructs a new client to the data store to work with data
+     * about catalogs configurations in the store.
+     *
+     * @param context The context of the data store with shared and cached data (base urls, for example)
+     */
+    constructor(private readonly context: DataStoreContext) {}
+
+    /**
+     * Asynchronously retrieves a list of catalogs that your account has access to.
+     * If set the schema, then will return filtered only catalogs (layers) by the specified layer schema HRN.
+     * If schema is not setted, then filter will return search for all.
+     */
+    public async getCatalogs(
+        catalogsRequest: CatalogsRequest
+    ): Promise<ConfigApi.CatalogsListResult> {
+        const configBaseUrl = await this.context.getBaseUrl("config");
+
+        return ConfigApi.getCatalogs(
+            new DataStoreRequestBuilder(
+                this.context.dm,
+                configBaseUrl,
+                this.context.getToken
+            ),
+            catalogsRequest.getSchema()
+                ? { verbose: "true", schemaHrn: catalogsRequest.getSchema() }
+                : {}
+        );
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/DataStoreClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/DataStoreClient.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { ArtifactApi, ConfigApi} from "@here/olp-sdk-dataservice-api";
+import { ArtifactApi, ConfigApi } from "@here/olp-sdk-dataservice-api";
 import { ErrorHTTPResponse } from "./CatalogClientCommon";
 import { DataStoreContext } from "./DataStoreContext";
 import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
@@ -42,7 +42,9 @@ export class DataStoreClient {
      * @param schemaHrn String representing schema HRN.
      * @returns Object with schema details.
      */
-    async getSchemaDetails(schemaHrn: string): Promise<ArtifactApi.GetSchemaResponse> {
+    async getSchemaDetails(
+        schemaHrn: string
+    ): Promise<ArtifactApi.GetSchemaResponse> {
         const artifactBaseUrl = await this.context.getBaseUrl("artifact");
 
         return ArtifactApi.getSchemaUsingGET(
@@ -104,27 +106,5 @@ export class DataStoreClient {
                 response
             );
         }
-    }
-
-    /**
-     * Asynchronously retrieves a list of catalogs which contain layer of certain schema that your
-     * account has access to.
-     *
-     * @param schemaHrn Schema HRN of layers to look for.
-     * @returns A promise with list of catalogs and their layers.
-     */
-    async getCatalogsBySchema(schemaHrn: string): Promise<ConfigApi.CatalogsListResult> {
-        const configBaseUrl = await this.context.getBaseUrl("config");
-        return ConfigApi.getCatalogs(
-            new DataStoreRequestBuilder(
-                this.context.dm,
-                configBaseUrl,
-                this.context.getToken
-            ),
-            {
-                verbose: "true",
-                schemaHrn
-            }
-        );
     }
 }

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogsRequest.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { CatalogsRequest } from "@here/olp-sdk-dataservice-read";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("CatalogsRequest", () => {
+    const mockedSchemaHRN1 = "hrn:::test-hrn1";
+    const mockedSchemaHRN2 = "hrn:::test-hrn2";
+
+    it("Should initialize", () => {
+        const catalogsRequest = new CatalogsRequest();
+
+        assert.isDefined(catalogsRequest);
+        expect(catalogsRequest).be.instanceOf(CatalogsRequest);
+    });
+
+    it("Should set parameters", () => {
+        const catalogsRequest = new CatalogsRequest();
+        const catalogsRequestWithSchemaHrn = catalogsRequest.withSchema(
+            mockedSchemaHRN1
+        );
+
+        expect(catalogsRequestWithSchemaHrn.getSchema()).to.be.equal(
+            mockedSchemaHRN1
+        );
+    });
+
+    it("Should set parameters with chain", () => {
+        const catalogsRequest = new CatalogsRequest()
+            .withSchema(mockedSchemaHRN1)
+            .withSchema(mockedSchemaHRN2);
+
+        expect(catalogsRequest.getSchema()).to.be.equal(mockedSchemaHRN2);
+    });
+});

--- a/@here/olp-sdk-dataservice-read/test/unit/ConfigClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ConfigClient.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { ConfigClient, CatalogsRequest } from "@here/olp-sdk-dataservice-read";
+import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
+import { ConfigApi } from "@here/olp-sdk-dataservice-api";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("ConfigClient", () => {
+    let sandbox: sinon.SinonSandbox;
+
+    let getCatalogsConfigStub: any;
+
+    const mockedHRN = "hrn:::test-hrn";
+
+    const fakeURL = "http://fake-base.url";
+
+    class MockedDataStoreContext {
+        constructor() {}
+
+        public async getBaseUrl() {
+            return Promise.resolve(fakeURL);
+        }
+    }
+
+    const mockedCatalogsHRN: ConfigApi.CatalogsListResult = {
+        results: {
+            items: [
+                { hrn: "hrn:::test-hrn" },
+                { hrn: "hrn:::test-hrn2" },
+                { hrn: "hrn:::test-hrn3" }
+            ]
+        }
+    };
+
+    const mockedCatalogsFilteredByHRN: ConfigApi.CatalogsListResult = {
+        results: { items: [{ hrn: "hrn:::test-hrn" }] }
+    };
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    beforeEach(() => {
+        sandbox
+            .stub(dataServiceRead, "DataStoreContext")
+            .callsFake(() => new MockedDataStoreContext());
+
+        getCatalogsConfigStub = sandbox.stub(ConfigApi, "getCatalogs");
+
+        getCatalogsConfigStub.callsFake(
+            (
+                builder: any,
+                params: any
+            ): Promise<ConfigApi.CatalogsListResult> => {
+                if (params.schemaHrn) {
+                    return Promise.resolve(mockedCatalogsFilteredByHRN);
+                }
+                return Promise.resolve(mockedCatalogsHRN);
+            }
+        );
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("Shoud be initialized with context", async () => {
+        const context = new MockedDataStoreContext();
+        const configClient = new ConfigClient(
+            (context as unknown) as dataServiceRead.DataStoreContext
+        );
+        assert.isDefined(configClient);
+    });
+
+    it("Should return all catalogs provided filtered by schema HRN.", async () => {
+        const context = new MockedDataStoreContext();
+        const configClient = new ConfigClient(
+            (context as unknown) as dataServiceRead.DataStoreContext
+        );
+
+        const CatalogsConfigRequest = new CatalogsRequest().withSchema(
+            mockedHRN
+        );
+        const getCatalogsResponse = (await configClient.getCatalogs(
+            CatalogsConfigRequest
+        )) as any;
+
+        assert.isDefined(getCatalogsResponse);
+        expect(getCatalogsResponse.results.items[0].hrn).to.be.equal(
+            "hrn:::test-hrn"
+        );
+        expect(getCatalogsResponse.results.items[1]).to.be.undefined;
+    });
+
+    it("Should return all catalogs provided without setted filter by schema HRN.", async () => {
+        const context = new MockedDataStoreContext();
+        const configClient = new ConfigClient(
+            (context as unknown) as dataServiceRead.DataStoreContext
+        );
+
+        const CatalogsConfigRequest = new CatalogsRequest();
+        const getCatalogsResponse = (await configClient.getCatalogs(
+            CatalogsConfigRequest
+        )) as any;
+
+        assert.isDefined(getCatalogsResponse);
+        expect(getCatalogsResponse.results.items[0].hrn).to.be.equal(
+            "hrn:::test-hrn"
+        );
+        expect(getCatalogsResponse.results.items[1].hrn).to.be.equal(
+            "hrn:::test-hrn2"
+        );
+        expect(getCatalogsResponse.results.items[2].hrn).to.be.equal(
+            "hrn:::test-hrn3"
+        );
+    });
+});


### PR DESCRIPTION
Move catalogs related code from DataStoreClient to ConfigClient.

* Create new class ConfigClient constructed with context.

* Move catalogs related code from DataStoreClient to ConfigClient.

* Add unit tests.

Relates-To: OLPEDGE-942.

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>
