### PR TITLE
OlpClientSettings with caching for alignment to the C++ SDK API

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/lookup-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/lookup-api.ts
@@ -54,19 +54,19 @@ export interface API {
     parameters?: { [key: string]: string };
 }
 
-export interface ModelError {
+export interface ApiNotFoundError {
     /**
      * Repetition of the HTTP error code
      */
-    code: number;
+    status: number;
     /**
      * Short description of the error
      */
-    message: string;
+    title: string;
     /**
-     * Complete description of the error
+     * Complete details of the error
      */
-    description?: string;
+    detail: Array<{name: string, error: string}>;
 }
 
 /* ===================================================================
@@ -83,7 +83,7 @@ export interface ModelError {
 export async function platformAPI(
     builder: RequestBuilder,
     params: { api: string; version: string }
-): Promise<API[]> {
+): Promise<API[] | ApiNotFoundError> {
     const baseUrl = "/platform/apis/{api}/{version}"
         .replace("{api}", UrlBuilder.toString(params["api"]))
         .replace("{version}", UrlBuilder.toString(params["version"]));
@@ -104,7 +104,7 @@ export async function platformAPI(
  *
  * @summary Return the list of the platform APIs.
  */
-export async function platformAPIList(builder: RequestBuilder): Promise<API[]> {
+export async function platformAPIList(builder: RequestBuilder): Promise<API[] | ApiNotFoundError> {
     const baseUrl = "/platform/apis";
 
     const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
@@ -135,7 +135,7 @@ export async function platformAPIList(builder: RequestBuilder): Promise<API[]> {
 export async function resourceAPI(
     builder: RequestBuilder,
     params: { hrn: string; api: string; version: string; region?: string }
-): Promise<API[]> {
+): Promise<API[] | ApiNotFoundError> {
     const baseUrl = "/resources/{hrn}/apis/{api}/{version}"
         .replace("{hrn}", UrlBuilder.toString(params["hrn"]))
         .replace("{api}", UrlBuilder.toString(params["api"]))
@@ -163,7 +163,7 @@ export async function resourceAPI(
 export async function resourceAPIList(
     builder: RequestBuilder,
     params: { hrn: string; region?: string }
-): Promise<API[]> {
+): Promise<API[] | ApiNotFoundError> {
     const baseUrl = "/resources/{hrn}/apis".replace(
         "{hrn}",
         UrlBuilder.toString(params["hrn"])

--- a/@here/olp-sdk-dataservice-api/package.json
+++ b/@here/olp-sdk-dataservice-api/package.json
@@ -23,7 +23,8 @@
   },
   "nyc": {
     "include": [
-      "lib/**/*.ts"
+      "lib/**/*.ts",
+      "dist/@here/olp-sdk-dataservice-api/**/*.js"
     ],
     "extension": [
       ".ts"

--- a/@here/olp-sdk-dataservice-read/index.ts
+++ b/@here/olp-sdk-dataservice-read/index.ts
@@ -21,6 +21,7 @@
 import "@here/olp-sdk-fetch";
 
 export * from "./lib/DataStoreClient";
+export * from "./lib/DataStoreDownloadManager";
 export * from "./lib/CatalogClient";
 export * from "./lib/HRN";
 export * from "./lib/CatalogClientCommon";
@@ -36,3 +37,9 @@ export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";
 export * from "./lib/ConfigClient";
 export * from "./lib/CatalogsRequest";
+export * from "./lib/utils/RequestBuilderFactory";
+export * from "./lib/utils/getEnvLookupUrl";
+export * from "./lib/client/OlpClientSettings";
+export * from "./lib/cache/ApiCacheRepository";
+export * from "./lib/cache/KeyValueCache";
+export * from "./lib/DataStoreRequestBuilder";

--- a/@here/olp-sdk-dataservice-read/index.web.ts
+++ b/@here/olp-sdk-dataservice-read/index.web.ts
@@ -18,6 +18,7 @@
  */
 
 export * from "./lib/DataStoreClient";
+export * from "./lib/DataStoreDownloadManager";
 export * from "./lib/CatalogClient";
 export * from "./lib/HRN";
 export * from "./lib/CatalogClientCommon";
@@ -33,3 +34,9 @@ export * from "./lib/VersionedLayerClient";
 export * from "./lib/VolatileLayerClient";
 export * from "./lib/ConfigClient";
 export * from "./lib/CatalogsRequest";
+export * from "./lib/utils/RequestBuilderFactory";
+export * from "./lib/utils/getEnvLookupUrl";
+export * from "./lib/client/OlpClientSettings";
+export * from "./lib/cache/ApiCacheRepository";
+export * from "./lib/cache/KeyValueCache";
+export * from "./lib/DataStoreRequestBuilder";

--- a/@here/olp-sdk-dataservice-read/lib/DataStoreContext.ts
+++ b/@here/olp-sdk-dataservice-read/lib/DataStoreContext.ts
@@ -18,10 +18,14 @@
  */
 
 import { LookupApi } from "@here/olp-sdk-dataservice-api";
-import { DataStoreDownloadManager } from "./DataStoreDownloadManager";
-import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
-import { DownloadManager } from "./DownloadManager";
-import { EnvironmentName, getEnvLookUpUrl } from "./getEnvLookupUrl";
+import {
+    ApiName,
+    DataStoreDownloadManager,
+    DataStoreRequestBuilder,
+    DownloadManager,
+    EnvironmentName,
+    getEnvLookUpUrl
+} from "@here/olp-sdk-dataservice-read";
 
 export interface DataStoreContextParams {
     // func, returns Promise with access token
@@ -31,23 +35,6 @@ export interface DataStoreContextParams {
     // Download manager for sending requests. Used default DataStoreDownloadManager if not set.
     dm?: DownloadManager;
 }
-
-/**
- * The list of API names of endpoints exists in the API
- */
-export type ApiName =
-    | "config"
-    | "artifact"
-    | "blob"
-    | "index"
-    | "ingest"
-    | "metadata"
-    | "notification"
-    | "publish"
-    | "query"
-    | "statistics"
-    | "stream"
-    | "volatile-blob";
 
 /**
  * DataStoreContext is the context, requires by DataStoreClient, CatalogClient or layers clients.
@@ -165,8 +152,11 @@ export class DataStoreContext {
             )
         );
 
-        this.apiListCache.set(this.cacheKeyForPlatformItems, apiList);
-        return Promise.resolve(apiList);
+        this.apiListCache.set(
+            this.cacheKeyForPlatformItems,
+            apiList as LookupApi.API[]
+        );
+        return Promise.resolve(apiList as LookupApi.API[]);
     }
 
     /**
@@ -186,9 +176,9 @@ export class DataStoreContext {
             )
         );
 
-        this.apiListCache.set(hrn, apiList);
+        this.apiListCache.set(hrn, apiList as LookupApi.API[]);
 
-        return Promise.resolve(apiList);
+        return Promise.resolve(apiList as LookupApi.API[]);
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/StatisticsClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/StatisticsClient.ts
@@ -18,16 +18,22 @@
  */
 
 import { CoverageApi } from "@here/olp-sdk-dataservice-api";
-import { DataStoreContext } from "./DataStoreContext";
-import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
-import { CoverageDataType, StatisticsRequest } from "./StatisticsRequest";
-import { SummaryRequest } from "./SummaryRequest";
+import {
+    CoverageDataType,
+    DataStoreRequestBuilder,
+    HRN,
+    OlpClientSettings,
+    RequestFactory,
+    StatisticsRequest,
+    SummaryRequest
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * A class that provides possibility to get Statistic Metadata and Data for Versioned layer
  */
 export class StatisticsClient {
-    constructor(private readonly context: DataStoreContext) {}
+    private readonly apiVersion: string = "v1";
+    constructor(private readonly settings: OlpClientSettings) {}
 
     /**
      * Fetch and return layer summary from the Statistics service.
@@ -79,7 +85,7 @@ export class StatisticsClient {
         }
         const coverageRequestBuilder = await this.getRequestBuilder(
             catalogHrn
-        ).catch(error => Promise.reject(new Error(error)));
+        ).catch(error => Promise.reject(error));
 
         let request;
         switch (typemap) {
@@ -119,17 +125,11 @@ export class StatisticsClient {
     private async getRequestBuilder(
         hrn: string
     ): Promise<DataStoreRequestBuilder> {
-        const url = await this.context
-            .getBaseUrl("statistics", hrn)
-            .catch(err =>
-                Promise.reject(
-                    `Error retrieving from cache builder for resource "${hrn}" and api: Statistic".\n${err}"`
-                )
-            );
-        return new DataStoreRequestBuilder(
-            this.context.dm,
-            url,
-            this.context.getToken
+        return RequestFactory.create(
+            "statistics",
+            this.apiVersion,
+            this.settings,
+            HRN.fromString(hrn)
         );
     }
 }

--- a/@here/olp-sdk-dataservice-read/lib/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/VersionedLayerClient.ts
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
+import { BlobApi, MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
+import { ApiName } from "./cache/ApiCacheRepository";
 import {
     AggregatedDownloadResponse,
     ErrorHTTPResponse,
     IndexMap
 } from "./CatalogClientCommon";
-import { ApiName, DataStoreContext } from "./DataStoreContext";
+import { DataStoreContext } from "./DataStoreContext";
 import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
-
-import { BlobApi, MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
 import { HRN } from "./HRN";
 import { LRUCache } from "./LRUCache";
 import { QuadKey } from "./partitioning/QuadKey";

--- a/@here/olp-sdk-dataservice-read/lib/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/VolatileLayerClient.ts
@@ -23,12 +23,13 @@ import {
     MetadataApi,
     QueryApi
 } from "@here/olp-sdk-dataservice-api";
+import { ApiName } from "./cache/ApiCacheRepository";
 import {
     AggregatedDownloadResponse,
     ErrorHTTPResponse,
     IndexMap
 } from "./CatalogClientCommon";
-import { ApiName, DataStoreContext } from "./DataStoreContext";
+import { DataStoreContext } from "./DataStoreContext";
 import { DataStoreRequestBuilder } from "./DataStoreRequestBuilder";
 import { LRUCache } from "./LRUCache";
 import { QuadKey } from "./partitioning/QuadKey";

--- a/@here/olp-sdk-dataservice-read/lib/cache/ApiCacheRepository.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/ApiCacheRepository.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { HRN } from "../HRN";
+import { KeyValueCache } from "./KeyValueCache";
+
+/**
+ * The list of API names of endpoints exists in the API
+ */
+export type ApiName =
+    | "config"
+    | "artifact"
+    | "blob"
+    | "index"
+    | "ingest"
+    | "metadata"
+    | "notification"
+    | "publish"
+    | "query"
+    | "statistics"
+    | "stream"
+    | "volatile-blob";
+
+/**
+ * Class for cache base urls to the API expecting a key,value pair.
+ * Key format is: <hrn>::<service_name>::<serviceVersion>::api
+ */
+export class ApiCacheRepository {
+    private readonly hrn: string;
+
+    constructor(private readonly cache: KeyValueCache, hrn?: HRN) {
+        this.hrn = hrn ? hrn.toString() : "platform-api";
+    }
+
+    /**
+     * Store key,value pair into the cache
+     * @param service The name of the service in the api
+     * @param serviceVersion The version of the service
+     * @param serviceUrl The base url of the service
+     * @return Returns true if the operation is successfull, false otherwise.
+     */
+    public put(
+        service: ApiName,
+        serviceVersion: string,
+        serviceUrl: string
+    ): boolean {
+        const key = this.createKey(this.hrn, service, serviceVersion);
+        return this.cache.put(key, serviceUrl);
+    }
+
+    /**
+     * Store key,value pair into the cache
+     * @param service
+     * @param serviceVersion
+     * @returns The base url of the service or undefined if not exists
+     */
+    public get(service: string, serviceVersion: string): string | undefined {
+        const key = this.createKey(this.hrn, service, serviceVersion);
+        return this.cache.get(key);
+    }
+
+    private createKey(
+        hrn: string,
+        service: string,
+        serviceVersion: string
+    ): string {
+        return hrn + "::" + service + "::" + serviceVersion + "::api";
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/cache/KeyValueCache.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/KeyValueCache.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/**
+ * Class for cache expecting a key,value pair.
+ */
+export class KeyValueCache {
+    private readonly cache: Map<string, string>;
+    constructor() {
+        this.cache = new Map();
+    }
+
+    /**
+     * Store key,value pair into the cache
+     *
+     * @param key Key for this value
+     * @param value The value of string type
+     * @return Returns true if the operation is successfull, false otherwise.
+     */
+    public put(key: string, value: string): boolean {
+        return this.cache.set(key, value).has(key);
+    }
+
+    /**
+     * Get key,value pair from the cache
+     *
+     * @param key Key to look for
+     */
+    public get(key: string): string | undefined {
+        return this.cache.get(key);
+    }
+
+    /**
+     * Remove a key,value pair from the cache
+     *
+     * @param key Key for the value to remove from cache
+     *
+     * @return Returns true if the operation is successfull, false otherwise.
+     */
+    public remove(key: string): boolean {
+        return this.cache.delete(key);
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/client/OlpClientSettings.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/OlpClientSettings.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+    DataStoreDownloadManager,
+    DownloadManager,
+    EnvironmentName,
+    KeyValueCache
+} from "@here/olp-sdk-dataservice-read";
+
+/**
+ * Params to construct the [[OlpClientSettings]]
+ */
+export interface OlpClientSettingsParams {
+    /**
+     * Async callback to return a [[Promise]] with token for requests.
+     *
+     * @example
+     * ```typescript
+     *  import { UserAuth } from "@here/olp-sdk-authentication";
+     *
+     *  const userAuth = new UserAuth(/** parameters **);
+     *  const getToken = userAuth.getToken();
+     * ```
+     */
+    getToken: () => Promise<string>;
+
+    /**
+     * Environment to use for getting url to the look-up api service.
+     * You can set the url to you custom service also.
+     *
+     * @example
+     *
+     * ```
+     *  'here' | 'here-dev' | 'http://127.0.0.1/my-local-api-service'
+     * ```
+     */
+    environment: EnvironmentName;
+
+    /**
+     * Download manager for sending requests.
+     * Used default [[DataStoreDownloadManager]] if not set.
+     *
+     * @see interface [[DownloadManager]]
+     */
+    dm?: DownloadManager;
+}
+
+/**
+ * OlpClient settings class. Use this class to configure the behaviour of the OlpClient.
+ */
+export class OlpClientSettings {
+    private keyValueCache: KeyValueCache;
+    private getValidToken: () => Promise<string>;
+    private env: EnvironmentName;
+    private dm: DownloadManager;
+
+    constructor(params: OlpClientSettingsParams) {
+        this.getValidToken = params.getToken;
+        this.env = params.environment;
+        this.dm = params.dm || new DataStoreDownloadManager();
+
+        this.keyValueCache = new KeyValueCache();
+    }
+
+    /**
+     * Download manager for sending requests.
+     */
+    get downloadManager(): DownloadManager {
+        return this.dm;
+    }
+
+    /**
+     * Async callback to return a [[Promise]] with token for requests
+     */
+    get token(): () => Promise<string> {
+        return this.getValidToken;
+    }
+
+    /**
+     * Environment to use for getting url to the look-up api service
+     */
+    get environment(): string {
+        return this.env;
+    }
+
+    /**
+     * Cache expecting a key,value pair
+     */
+    get cache(): KeyValueCache {
+        return this.keyValueCache;
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { LookupApi } from "@here/olp-sdk-dataservice-api";
+import {
+    ApiCacheRepository,
+    ApiName,
+    DataStoreRequestBuilder,
+    getEnvLookUpUrl,
+    HRN,
+    OlpClientSettings
+} from "@here/olp-sdk-dataservice-read";
+
+/**
+ * The helper utils for making Request object with base urls to the services from
+ * lookup api, token callback and download manager.
+ *
+ * Also can be used for getting base url to the service from lookup api.
+ */
+export class RequestFactory {
+    /**
+     * Factory method for building [[DataStoreRequestBuilder]]
+     * @param serviceName The name of the service in API
+     * @param serviceVersion The version of the service
+     * @param settings Instance of [[OlpClientSettings]]
+     * @param hrn Optional [[HRN]] for the catalog
+     *
+     * @returns The [[Promise]] with constructed [[DataStoreRequestBuilder]]
+     */
+    public static async create(
+        serviceName: ApiName,
+        serviceVersion: string,
+        settings: OlpClientSettings,
+        hrn?: HRN
+    ): Promise<DataStoreRequestBuilder> {
+        return RequestFactory.getBaseUrl(
+            serviceName,
+            serviceVersion,
+            settings,
+            hrn
+        )
+            .then(async (baseUrl: string) =>
+                baseUrl
+                    ? Promise.resolve(
+                          new DataStoreRequestBuilder(
+                              settings.downloadManager,
+                              baseUrl,
+                              settings.token
+                          )
+                      )
+                    : Promise.reject(
+                          `Error getting base url to the service: ${serviceName}`
+                      )
+            )
+            .catch(error =>
+                Promise.reject(
+                    `Error building Request for service: ${serviceName}.\n${error}`
+                )
+            );
+    }
+
+    /**
+     * Getts base url to the API service with caching support.
+     *
+     * @param serviceName The name of the service in API
+     * @param serviceVersion The version of the service
+     * @param settings Instance of [[OlpClientSettings]]
+     * @param hrn Optional [[HRN]] for the catalog
+     *
+     * @returns The [[Promise]] with the base url to the service
+     */
+    public static async getBaseUrl(
+        serviceName: ApiName,
+        serviceVersion: string,
+        settings: OlpClientSettings,
+        hrn?: HRN
+    ): Promise<string> {
+        const apiCache = new ApiCacheRepository(settings.cache, hrn);
+        const baseUrl = apiCache.get(serviceName, serviceVersion);
+        if (baseUrl) {
+            return Promise.resolve(baseUrl);
+        }
+
+        const lookUpUrl = getEnvLookUpUrl(settings.environment);
+        const lookUpApiRequest = new DataStoreRequestBuilder(
+            settings.downloadManager,
+            lookUpUrl,
+            settings.token
+        );
+
+        const apiService = hrn ? LookupApi.resourceAPI : LookupApi.platformAPI;
+        const params: {
+            api: string;
+            version: string;
+            hrn: string;
+            region?: string | undefined;
+        } = {
+            api: serviceName,
+            version: serviceVersion,
+            hrn: ""
+        };
+
+        if (hrn) {
+            params.hrn = hrn.toString();
+        }
+
+        return apiService(lookUpApiRequest, params)
+            .then(
+                async (
+                    result: LookupApi.API[] | LookupApi.ApiNotFoundError
+                ) => {
+                    if (result instanceof Array && result[0].baseURL) {
+                        apiCache.put(
+                            serviceName,
+                            serviceVersion,
+                            result[0].baseURL
+                        );
+                        return Promise.resolve(result[0].baseURL);
+                    }
+
+                    if (!(result instanceof Array) && result.status === 404) {
+                        return Promise.reject(
+                            `Getting API error: ${result.title}`
+                        );
+                    }
+
+                    return Promise.reject(
+                        `Getting API ${serviceName} unknown error`
+                    );
+                }
+            )
+            .catch((error: string) =>
+                Promise.reject(`Getting API ${serviceName} error: ${error}`)
+            );
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/utils/getEnvLookupUrl.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/getEnvLookupUrl.ts
@@ -44,7 +44,8 @@ export function getEnvLookUpUrl(env: EnvironmentName): string {
             "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*";
         const tld = `(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))\\.?`;
         const port = "(?::\\d{2,5})?";
-        const path = "(?:[/?#][^\\s\"]*)?";
+        // tslint:disable-next-line: quotemark
+        const path = '(?:[/?#][^\\s"]*)?';
         const regex = new RegExp(
             `(?:${protocol}|www\\.)(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`
         );

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -21,7 +21,8 @@
   },
   "nyc": {
     "include": [
-      "lib/**/*.ts"
+      "lib/**/*.ts",
+      "dist/@here/olp-sdk-dataservice-read/**/*.js"
     ],
     "extension": [
       ".ts"

--- a/@here/olp-sdk-dataservice-read/test/getEnvLookupUrl.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/getEnvLookupUrl.test.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { getEnvLookUpUrl } from "../lib/getEnvLookupUrl";
+import { getEnvLookUpUrl } from "../lib/utils/getEnvLookupUrl";
 
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");

--- a/@here/olp-sdk-dataservice-read/test/unit/OlpClientSettings.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/OlpClientSettings.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
+chai.use(sinonChai);
+const expect = chai.expect;
+
+class MockedKeyValueCache {
+    private readonly cache: Map<string, string>;
+    constructor() {
+        this.cache = new Map();
+        this.cache.set("test-cached-item-key", "test-cached-value");
+    }
+
+    get(key: string) {
+        return this.cache.get(key);
+    }
+}
+
+class MockedDataStoreDownloadManager {
+    public async download(url: string, init?: RequestInit) {
+        return Promise.resolve(
+            new Response("test-download-manager-downloaded-result")
+        );
+    }
+}
+
+class MockedCustomDataStoreDownloadManager {
+    public async download(url: string, init?: RequestInit) {
+        return Promise.resolve(
+            new Response("test-custom-download-manager-downloaded-result")
+        );
+    }
+}
+
+describe("OlpClientSettings", () => {
+    let KeyValueCacheStub: sinon.SinonStub;
+    let DataStoreDownloadManagerStub: sinon.SinonStub;
+
+    let sandbox: sinon.SinonSandbox;
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    beforeEach(() => {
+        KeyValueCacheStub = sandbox.stub(dataServiceRead, "KeyValueCache");
+        KeyValueCacheStub.callsFake((cache, hrn) => new MockedKeyValueCache());
+
+        DataStoreDownloadManagerStub = sandbox.stub(
+            dataServiceRead,
+            "DataStoreDownloadManager"
+        );
+        DataStoreDownloadManagerStub.callsFake(
+            (cache, hrn) => new MockedDataStoreDownloadManager()
+        );
+    });
+
+    it("Should be configured with correct params and default download manager", async () => {
+        const settings = new dataServiceRead.OlpClientSettings({
+            environment: "test-env",
+            getToken: () => Promise.resolve("test-token")
+        });
+
+        expect(settings.cache.get("test-cached-item-key")).equal(
+            "test-cached-value"
+        );
+        expect(settings.environment).equal("test-env");
+
+        const downloadedResult = await settings.downloadManager.download(
+            "fake-url"
+        );
+        expect(downloadedResult.body).equal(
+            "test-download-manager-downloaded-result"
+        );
+
+        const tokenStr = await settings.token();
+        expect(tokenStr).equal("test-token");
+    });
+
+    it("Should be configured with correct params and custom download manager", async () => {
+        const settings = new dataServiceRead.OlpClientSettings({
+            environment: "test-env",
+            getToken: () => Promise.resolve("test-token"),
+            dm: new MockedCustomDataStoreDownloadManager()
+        });
+
+        const downloadedResult = await settings.downloadManager.download(
+            "fake-url"
+        );
+        expect(downloadedResult.body).equal(
+            "test-custom-download-manager-downloaded-result"
+        );
+    });
+});

--- a/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
+import * as dataServiceApi from "@here/olp-sdk-dataservice-api";
+chai.use(sinonChai);
+const expect = chai.expect;
+
+class MockedHrn {
+    constructor(private readonly data: dataServiceRead.HRNData) {}
+    toString(): string {
+        return (
+            "hrn:" +
+            this.data.partition +
+            ":" +
+            this.data.service +
+            ":" +
+            (this.data.region === undefined ? "" : this.data.region) +
+            ":" +
+            (this.data.account === undefined ? "" : this.data.account) +
+            ":" +
+            this.data.resource
+        );
+    }
+}
+
+class MockedOlpClientSettings {
+    private keyValueCache = new Map();
+
+    constructor() {}
+    get cache() {
+        return this.keyValueCache;
+    }
+    get environment() {
+        return "test-env";
+    }
+    get token() {
+        return Promise.resolve("mocked-token");
+    }
+    get downloadManager() {
+        return {
+            download: (url: string) => Promise.resolve("mocked-results")
+        };
+    }
+}
+
+class MockedApiCacheRepository {
+    private readonly hrn: string;
+    constructor(private readonly cache: Map<string, string>, hrn?: MockedHrn) {
+        this.hrn = hrn ? hrn.toString() : "plathorm-api";
+    }
+
+    public get(service: string, serviceVersion: string) {
+        return this.cache.get(`${service}-${serviceVersion}`);
+    }
+
+    public put(
+        serviceName: string,
+        serviceVersion: string,
+        baseURL: string
+    ): boolean {
+        this.cache.set(`${serviceName}-${serviceVersion}`, baseURL);
+        return true;
+    }
+}
+
+class MockedDataStoreRequestBuilder {
+    constructor(
+        readonly downloadManager: dataServiceRead.DownloadManager,
+        public readonly baseUrl: string,
+        private readonly getBearerToken: () => Promise<string>
+    ) {}
+}
+
+describe("RequestFactory", () => {
+    let ApiCacheRepositoryStub: sinon.SinonStub;
+    let DataStoreRequestBuilderStub: sinon.SinonStub;
+
+    let sandbox: sinon.SinonSandbox;
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    beforeEach(() => {
+        ApiCacheRepositoryStub = sandbox.stub(
+            dataServiceRead,
+            "ApiCacheRepository"
+        );
+        ApiCacheRepositoryStub.callsFake(
+            (cache, hrn) => new MockedApiCacheRepository(cache, hrn)
+        );
+
+        DataStoreRequestBuilderStub = sandbox.stub(
+            dataServiceRead,
+            "DataStoreRequestBuilder"
+        );
+        DataStoreRequestBuilderStub.callsFake((dm, url, token) => {
+            return new MockedDataStoreRequestBuilder(dm, url, token);
+        });
+
+        sandbox
+            .stub(dataServiceRead, "getEnvLookUpUrl")
+            .callsFake(() => "http://fake-lookup.service.url");
+    });
+
+    describe("create()", () => {
+        it("Should return created RequestBuilder with correct base url for platform service", async () => {
+            sandbox
+                .stub(dataServiceApi.LookupApi, "platformAPI")
+                .callsFake(() =>
+                    Promise.resolve([
+                        {
+                            api: "test-api",
+                            version: "v1",
+                            baseURL:
+                                "test-base-url-to-platform-service-for-request-builder"
+                        }
+                    ])
+                );
+
+            const settings = new MockedOlpClientSettings();
+            const requestBuilder = await dataServiceRead.RequestFactory.create(
+                "statistics",
+                "v1",
+                settings as any
+            );
+
+            expect(requestBuilder.baseUrl).to.be.equal(
+                "test-base-url-to-platform-service-for-request-builder"
+            );
+        });
+
+        it("Should reject with correct error about base url", async () => {
+            sandbox.stub(dataServiceApi.LookupApi, "platformAPI").callsFake(
+                () =>
+                    Promise.resolve([
+                        {
+                            api: "test-api",
+                            version: "v1",
+                            baseURL: undefined
+                        }
+                    ]) as any
+            );
+
+            const settings = new MockedOlpClientSettings();
+
+            try {
+                await dataServiceRead.RequestFactory.create(
+                    "statistics",
+                    "v1",
+                    settings as any
+                );
+            } catch (error) {
+                expect(error).to.be.equal(
+                    "Error building Request for service: statistics.\nGetting API statistics error: Getting API statistics unknown error"
+                );
+            }
+        });
+    });
+
+    describe("getBaseUrl()", () => {
+        it("Should return correct base url for platform service", async () => {
+            sandbox
+                .stub(dataServiceApi.LookupApi, "platformAPI")
+                .callsFake(() =>
+                    Promise.resolve([
+                        {
+                            api: "test-api",
+                            version: "v1",
+                            baseURL: "test-base-url-to-platform-service"
+                        }
+                    ])
+                );
+            const settings = new MockedOlpClientSettings();
+            const baseUrl = await dataServiceRead.RequestFactory.getBaseUrl(
+                "statistics",
+                "v1",
+                settings as any
+            );
+            expect(baseUrl).to.be.equal("test-base-url-to-platform-service");
+        });
+
+        it("Should return correct base url for resource service", async () => {
+            sandbox
+                .stub(dataServiceApi.LookupApi, "resourceAPI")
+                .callsFake(() =>
+                    Promise.resolve([
+                        {
+                            api: "test-api",
+                            version: "v1",
+                            baseURL: "test-base-url-to-resource-cervice"
+                        }
+                    ])
+                );
+            const settings = new MockedOlpClientSettings();
+
+            const baseUrl = await dataServiceRead.RequestFactory.getBaseUrl(
+                "statistics",
+                "v1",
+                settings as any,
+                new MockedHrn({
+                    partition: "here-dev",
+                    resource: "here-test-resource",
+                    service: "here-test-service"
+                }) as any
+            );
+            expect(baseUrl).to.be.equal("test-base-url-to-resource-cervice");
+        });
+
+        it("Should reject with correct error message", async () => {
+            sandbox
+                .stub(dataServiceApi.LookupApi, "platformAPI")
+                .callsFake(() =>
+                    Promise.resolve({
+                        status: 404,
+                        title: "Not Found",
+                        detail: []
+                    })
+                );
+            const settings = new MockedOlpClientSettings();
+            try {
+                await dataServiceRead.RequestFactory.getBaseUrl(
+                    "statistics",
+                    "v1",
+                    settings as any
+                );
+            } catch (error) {
+                expect(error).to.be.equal(
+                    "Getting API statistics error: Getting API error: Not Found"
+                );
+            }
+        });
+
+        it("Should reject with unknown error message", async () => {
+            sandbox
+                .stub(dataServiceApi.LookupApi, "platformAPI")
+                .callsFake(() =>
+                    Promise.resolve({
+                        status: 500,
+                        title: "Internal server error",
+                        detail: []
+                    })
+                );
+            const settings = new MockedOlpClientSettings();
+            try {
+                await dataServiceRead.RequestFactory.getBaseUrl(
+                    "statistics",
+                    "v1",
+                    settings as any
+                );
+            } catch (error) {
+                expect(error).to.be.equal(
+                    "Getting API statistics error: Getting API statistics unknown error"
+                );
+            }
+        });
+
+        it("Should return correct base url for resource service from cache", async () => {
+            const resourceApiStub = sandbox.stub(
+                dataServiceApi.LookupApi,
+                "resourceAPI"
+            );
+            const platformApiStub = sandbox.stub(
+                dataServiceApi.LookupApi,
+                "platformAPI"
+            );
+            const settings = new MockedOlpClientSettings();
+            settings.cache.set("statistics-v1", "test-cached-service-url");
+
+            const baseUrl = await dataServiceRead.RequestFactory.getBaseUrl(
+                "statistics",
+                "v1",
+                settings as any,
+                new MockedHrn({
+                    partition: "here-dev",
+                    resource: "here-test-resource",
+                    service: "here-test-service"
+                }) as any
+            );
+            expect(baseUrl).to.be.equal("test-cached-service-url");
+            expect(resourceApiStub.callCount).to.be.equal(0);
+            expect(platformApiStub.callCount).to.be.equal(0);
+        });
+    });
+});

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
@@ -21,47 +21,39 @@ import sinon = require("sinon");
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-import {
-    CoverageDataType,
-    HRN,
-    StatisticsClient,
-    StatisticsRequest,
-    SummaryRequest
-} from "@here/olp-sdk-dataservice-read";
 import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
 import { CoverageApi } from "@here/olp-sdk-dataservice-api";
 
 chai.use(sinonChai);
 
 const assert = chai.assert;
-const expect = chai.expect;
 
 describe("StatistiscClient", () => {
     let sandbox: sinon.SinonSandbox;
-    let getDataCoverageSummaryStub: any;
-    let getStatisticsBitMapStub: any;
-    let getStatisticsSizeMapStub: any;
-    let getStatisticsTimeMapStub: any;
-    const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
+    let olpClientSettingsStub: sinon.SinonStubbedInstance<
+        dataServiceRead.OlpClientSettings
+    >;
+    let getDataCoverageSummaryStub: sinon.SinonStub;
+    let getStatisticsBitMapStub: sinon.SinonStub;
+    let getStatisticsSizeMapStub: sinon.SinonStub;
+    let getStatisticsTimeMapStub: sinon.SinonStub;
+    let getBaseUrlRequestStub: sinon.SinonStub;
+    const mockedHRN = dataServiceRead.HRN.fromString("hrn:here:data:::mocked-hrn");
     const mockedLayerId = "mocked-layed-id";
     const fakeURL = "http://fake-base.url";
-
-    class MockedDataStoreContext {
-        constructor() {}
-
-        public async getBaseUrl() {
-            return Promise.resolve(fakeURL);
-        }
-    }
 
     before(() => {
         sandbox = sinon.createSandbox();
     });
 
     beforeEach(() => {
-        sandbox
-            .stub(dataServiceRead, "DataStoreContext")
-            .callsFake(() => new MockedDataStoreContext());
+        olpClientSettingsStub = sandbox.createStubInstance(
+            dataServiceRead.OlpClientSettings
+        );
+        getBaseUrlRequestStub = sandbox.stub(
+            dataServiceRead.RequestFactory,
+            "getBaseUrl"
+        );
         getDataCoverageSummaryStub = sandbox.stub(
             CoverageApi,
             "getDataCoverageSummary"
@@ -78,6 +70,8 @@ describe("StatistiscClient", () => {
             CoverageApi,
             "getDataCoverageTimeMap"
         );
+
+        getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
     afterEach(() => {
@@ -85,9 +79,8 @@ describe("StatistiscClient", () => {
     });
 
     it("Shoud be initialised with context", async () => {
-        const context = new MockedDataStoreContext();
-        const statisticsClient = new StatisticsClient(
-            (context as unknown) as dataServiceRead.DataStoreContext
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
         );
         assert.isDefined(statisticsClient);
     });
@@ -114,9 +107,8 @@ describe("StatistiscClient", () => {
                 }
             }
         };
-        const context = new MockedDataStoreContext();
-        const statisticsClient = new StatisticsClient(
-            (context as unknown) as dataServiceRead.DataStoreContext
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
         );
         assert.isDefined(statisticsClient);
         getDataCoverageSummaryStub.callsFake(
@@ -125,7 +117,7 @@ describe("StatistiscClient", () => {
             }
         );
 
-        const summaryRequest = new SummaryRequest()
+        const summaryRequest = new dataServiceRead.SummaryRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId);
 
@@ -135,9 +127,8 @@ describe("StatistiscClient", () => {
 
     it("Should method getStatistics provide data", async () => {
         const mockedStatistics: Response = new Response("mocked-response");
-        const context = new MockedDataStoreContext();
-        const statisticsClient = new StatisticsClient(
-            (context as unknown) as dataServiceRead.DataStoreContext
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
         );
         assert.isDefined(statisticsClient);
         getStatisticsBitMapStub.callsFake(
@@ -156,33 +147,33 @@ describe("StatistiscClient", () => {
             }
         );
 
-        const statisticBitMapRequest = new StatisticsRequest()
+        const statisticBitMapRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
             .withDataLevel("12")
-            .withTypemap(CoverageDataType.BITMAP);
+            .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
 
         const statisticBitMap = await statisticsClient.getStatistics(
             statisticBitMapRequest
         );
         assert.isDefined(statisticBitMap);
 
-        const statisticSizeMapRequest = new StatisticsRequest()
+        const statisticSizeMapRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
             .withDataLevel("12")
-            .withTypemap(CoverageDataType.SIZEMAP);
+            .withTypemap(dataServiceRead.CoverageDataType.SIZEMAP);
 
         const statisticSizeMap = await statisticsClient.getStatistics(
             statisticSizeMapRequest
         );
         assert.isDefined(statisticSizeMap);
 
-        const statisticTimeMapRequest = new StatisticsRequest()
+        const statisticTimeMapRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
             .withDataLevel("12")
-            .withTypemap(CoverageDataType.TIMEMAP);
+            .withTypemap(dataServiceRead.CoverageDataType.TIMEMAP);
 
         const statisticTimeMap = await statisticsClient.getStatistics(
             statisticTimeMapRequest


### PR DESCRIPTION
* Add new class OlpClientSettings for replacing DataStoreContext in terms of alignment to the C++ SDK API.
* Add KeyValueCache class for caching by SDK.
* Add ApiCacheRepository class for caching service URLs from lookup api.
* Add RequestBuilderFactory for improving the codebase and ability to build Request objects in one place
* Replace DataStoreContext with OlpClientSettings in the StatisticsClient class
* Fix settings for generating test coverage
* Fix founded issues in the olp-sdk-dataservice-api->look-up service 
* Fix found issues in DataStoreContext tests.
* Update StatisticsClient tests.
* Add unit tests for RequestFactory, OlpClientSettings.

Resolves: OLPEDGE-961

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>