### PR TITLE
Remove RequestInit optional params from Public API

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/DataStoreDownloadManager.ts
+++ b/@here/olp-sdk-dataservice-read/lib/DataStoreDownloadManager.ts
@@ -102,7 +102,7 @@ export class DataStoreDownloadManager implements DownloadManager {
                 (err.hasOwnProperty("name") && err.name === "AbortError") ||
                 retryCount > maxRetries
             ) {
-                throw err;
+                return Promise.reject(err);
             }
         }
         return DataStoreDownloadManager.waitFor(

--- a/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
@@ -40,6 +40,9 @@ export class RequestFactory {
      * @param serviceVersion The version of the service
      * @param settings Instance of [[OlpClientSettings]]
      * @param hrn Optional [[HRN]] for the catalog
+     * @param abortSignal A signal object that allows you to communicate with a request (such as a Fetch)
+     * and abort it if required via an AbortController object
+     *  @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      *
      * @returns The [[Promise]] with constructed [[DataStoreRequestBuilder]]
      */
@@ -47,7 +50,8 @@ export class RequestFactory {
         serviceName: ApiName,
         serviceVersion: string,
         settings: OlpClientSettings,
-        hrn?: HRN
+        hrn?: HRN,
+        abortSignal?: AbortSignal
     ): Promise<DataStoreRequestBuilder> {
         return RequestFactory.getBaseUrl(
             serviceName,
@@ -61,7 +65,8 @@ export class RequestFactory {
                           new DataStoreRequestBuilder(
                               settings.downloadManager,
                               baseUrl,
-                              settings.token
+                              settings.token,
+                              abortSignal
                           )
                       )
                     : Promise.reject(


### PR DESCRIPTION
* Implement the possibility for the user to pass the abort signal for the method getData and abort downloading partition if need.
* Add unit test to the VersionedLayerClient.getData()

Resolves: OLPEDGE-972

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>