### PR TITLE
Update VolatileLayerClient and tests

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/volatile-blob-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/volatile-blob-api.ts
@@ -155,7 +155,7 @@ export async function getVolatileBlob(
         dataHandle: string;
         billingTag?: string;
     }
-): Promise<string> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/data/{dataHandle}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{dataHandle}", UrlBuilder.toString(params["dataHandle"]));
@@ -169,7 +169,7 @@ export async function getVolatileBlob(
         headers
     };
 
-    return builder.request<string>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**

--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogRequest.ts
@@ -29,8 +29,9 @@ export class CatalogRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): CatalogRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogVersionRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogVersionRequest.ts
@@ -61,8 +61,9 @@ export class CatalogVersionRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): CatalogVersionRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogsRequest.ts
@@ -45,8 +45,9 @@ export class CatalogsRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): CatalogsRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/DataRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/DataRequest.ts
@@ -89,8 +89,9 @@ export class DataRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): DataRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
@@ -46,8 +46,9 @@ export class PartitionsRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): PartitionsRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/QuadTreeIndexRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QuadTreeIndexRequest.ts
@@ -31,6 +31,7 @@ export class QuadTreeIndexRequest {
     private quadKey?: QuadKey;
     private depth?: number;
     private billingTag?: string;
+    
 
     /**
      * Constructs the [[QuadTreeIndexRequest]] for fetching Quad tree index from Query API
@@ -82,6 +83,15 @@ export class QuadTreeIndexRequest {
     }
 
     /**
+     * Billing Tag is an optional free-form tag which is used for grouping billing records together.
+     * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
+     */
+    public withBillingTag(tag: string): QuadTreeIndexRequest {
+        this.billingTag = validateBillingTag(tag);
+        return this;
+    }
+
+    /**
      * The configured catalog version for the request
      */
     public getVersion(): number | undefined {
@@ -105,30 +115,22 @@ export class QuadTreeIndexRequest {
     /**
      * The configured type of layer for request
      */
-    getLayerType() {
+    public getLayerType() {
         return this.layerType;
     }
 
     /**
      * The configured [[HRN]] instance of the catalog hrn for request
      */
-    getCatalogHrn(): HRN {
+    public getCatalogHrn(): HRN {
         return this.catalogHrn;
     }
 
     /**
      * The layer id for request
      */
-    getLayerId(): string | undefined {
+    public getLayerId(): string | undefined {
         return this.layerId;
-    }
-
-    /**
-     * Billing Tag is an optional free-form tag which is used for grouping billing records together.
-     * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     */
-    public withBillingTag(tag: string) {
-        this.billingTag = validateBillingTag(tag);
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/SchemaDetailsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SchemaDetailsRequest.ts
@@ -44,8 +44,9 @@ export class SchemaDetailsRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): SchemaDetailsRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/SchemaRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SchemaRequest.ts
@@ -45,8 +45,9 @@ export class SchemaRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): SchemaRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/StatisticsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StatisticsRequest.ts
@@ -100,8 +100,9 @@ export class StatisticsRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): StatisticsRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/SummaryRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SummaryRequest.ts
@@ -59,8 +59,9 @@ export class SummaryRequest {
      * Billing Tag is an optional free-form tag which is used for grouping billing records together.
      * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
      */
-    public withBillingTag(tag: string) {
+    public withBillingTag(tag: string): SummaryRequest {
         this.billingTag = validateBillingTag(tag);
+        return this;
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { BlobApi, MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
+import { MetadataApi, QueryApi, VolatileBlobApi } from "@here/olp-sdk-dataservice-api";
 import {
     ApiName,
     DataRequest,
@@ -145,20 +145,10 @@ export class VolatileLayerClient {
                 .withQuadKey(quadKey)
                 .withDepth(request.getDepth());
 
-            const quadTreeIndex = await queryClient.fetchQuadTreeIndex(
+            return queryClient.fetchQuadTreeIndex(
                 quadTreeIndexRequest,
                 abortSignal
             );
-
-            const result: MetadataApi.Partitions = {
-                partitions: quadTreeIndex.subQuads.map(subQuad => ({
-                    dataHandle: subQuad.dataHandle,
-                    version: subQuad.version,
-                    partition: mortonCodeFromQuadKey(quadKey).toString()
-                }))
-            };
-
-            return Promise.resolve(result);
         }
 
         const metaRequestBilder = await this.getRequestBuilder(
@@ -177,11 +167,11 @@ export class VolatileLayerClient {
         billingTag?: string
     ): Promise<Response> {
         const builder = await this.getRequestBuilder(
-            "blob",
+            "volatile-blob",
             HRN.fromString(this.hrn),
             abortSignal
         );
-        return BlobApi.getBlob(builder, {
+        return VolatileBlobApi.getVolatileBlob(builder, {
             dataHandle,
             layerId: this.layerId,
             billingTag

--- a/@here/olp-sdk-dataservice-read/lib/utils/validateBillingTag.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/validateBillingTag.ts
@@ -27,7 +27,7 @@
 export function validateBillingTag(tag: string): string {
     const pattern = /^[A-Za-z0-9_-]{4,16}$/;
 
-    if (pattern.test(tag)) {
+    if (!pattern.test(tag)) {
         throw new Error(
             "The billing tag must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9]"
         );

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogRequest.test.ts
@@ -28,11 +28,20 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SummaryRequest", () => {
+describe("CatalogRequest", () => {
+    const billingTag = "billingTag";
+
     it("Should initialize", () => {
         const catalogRequest = new CatalogRequest();
 
         assert.isDefined(CatalogRequest);
         expect(catalogRequest).be.instanceOf(CatalogRequest);
+    });
+
+    it("Should set parameters", () => {
+        const catalogRequest = new CatalogRequest();
+        const catalogRequestWithBillTag = catalogRequest.withBillingTag(billingTag);
+
+        expect(catalogRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogVersionRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogVersionRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("CatalogVersionRequest", () => {
+    const billingTag = "billingTag";
     const mockedStartVersion = 13;
     const mockedEndVersion = 42;
 
@@ -42,29 +43,23 @@ describe("CatalogVersionRequest", () => {
     it("Should set parameters", () => {
         const catalogVersionRequest = new CatalogVersionRequest();
 
-        const catalogStartVersion = catalogVersionRequest.withStartVersion(
-            mockedStartVersion
-        );
-        const catalogEndVersion = catalogVersionRequest.withEndVersion(
-            mockedEndVersion
-        );
+        const catalogStartVersion = catalogVersionRequest.withStartVersion(mockedStartVersion);
+        const catalogEndVersion = catalogVersionRequest.withEndVersion(mockedEndVersion);
+        const catalogBillTag = catalogVersionRequest.withBillingTag(billingTag);
 
-        expect(catalogStartVersion.getStartVersion()).to.be.equal(
-            mockedStartVersion
-        );
+        expect(catalogStartVersion.getStartVersion()).to.be.equal(mockedStartVersion);
         expect(catalogEndVersion.getEndVersion()).to.be.equal(mockedEndVersion);
+        expect(catalogBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 
     it("Should get parameters with chain", () => {
         const catalogVersionRequest = new CatalogVersionRequest()
             .withStartVersion(mockedStartVersion)
-            .withEndVersion(mockedEndVersion);
+            .withEndVersion(mockedEndVersion)
+            .withBillingTag(billingTag);
 
-        expect(catalogVersionRequest.getStartVersion()).to.be.equal(
-            mockedStartVersion
-        );
-        expect(catalogVersionRequest.getEndVersion()).to.be.equal(
-            mockedEndVersion
-        );
+        expect(catalogVersionRequest.getStartVersion()).to.be.equal(mockedStartVersion);
+        expect(catalogVersionRequest.getEndVersion()).to.be.equal(mockedEndVersion);
+        expect(catalogVersionRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogsRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("CatalogsRequest", () => {
+    const billingTag = "billingTag";
     const mockedSchemaHRN1 = "hrn:::test-hrn1";
     const mockedSchemaHRN2 = "hrn:::test-hrn2";
 
@@ -41,20 +42,20 @@ describe("CatalogsRequest", () => {
 
     it("Should set parameters", () => {
         const catalogsRequest = new CatalogsRequest();
-        const catalogsRequestWithSchemaHrn = catalogsRequest.withSchema(
-            mockedSchemaHRN1
-        );
+        const catalogsRequestWithSchemaHrn = catalogsRequest.withSchema(mockedSchemaHRN1);
+        const catalogsRequestWithBillTag = catalogsRequest.withBillingTag(billingTag);
 
-        expect(catalogsRequestWithSchemaHrn.getSchema()).to.be.equal(
-            mockedSchemaHRN1
-        );
+        expect(catalogsRequestWithSchemaHrn.getSchema()).to.be.equal(mockedSchemaHRN1);
+        expect(catalogsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 
     it("Should set parameters with chain", () => {
         const catalogsRequest = new CatalogsRequest()
             .withSchema(mockedSchemaHRN1)
-            .withSchema(mockedSchemaHRN2);
+            .withSchema(mockedSchemaHRN2)
+            .withBillingTag(billingTag);
 
         expect(catalogsRequest.getSchema()).to.be.equal(mockedSchemaHRN2);
+        expect(catalogsRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/DataRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/DataRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("DataRequest", () => {
+    const billingTag = "billingTag";
     const mockedDataHandle = "43d76b9f-e934-40e5-9ce4-91d88a30f1c6";
     const mockedPartitionId = "123123123";
     const mockedVersion = 42;
@@ -47,25 +48,17 @@ describe("DataRequest", () => {
 
     it("Should set parameters", () => {
         const dataRequest = new DataRequest();
-        const dataRequestWithCatalogHrn = dataRequest.withDataHandle(
-            mockedDataHandle
-        );
-        const dataRequestWithLayerId = dataRequest.withPartitionId(
-            mockedPartitionId
-        );
+        const dataRequestWithCatalogHrn = dataRequest.withDataHandle(mockedDataHandle);
+        const dataRequestWithLayerId = dataRequest.withPartitionId(mockedPartitionId);
         const dataRequestWithDataLevel = dataRequest.withQuadKey(mockedQuadKey);
         const dataRequestWithTimemap = dataRequest.withVersion(mockedVersion);
+        const dataRequestWithBillTag = dataRequest.withBillingTag(billingTag);
 
-        expect(dataRequestWithCatalogHrn.getDataHandle()).to.be.equal(
-            mockedDataHandle
-        );
-        expect(dataRequestWithLayerId.getPartitionId()).to.be.equal(
-            mockedPartitionId
-        );
-        expect(dataRequestWithDataLevel.getQuadKey()).to.be.equal(
-            mockedQuadKey
-        );
+        expect(dataRequestWithCatalogHrn.getDataHandle()).to.be.equal(mockedDataHandle);
+        expect(dataRequestWithLayerId.getPartitionId()).to.be.equal(mockedPartitionId);
+        expect(dataRequestWithDataLevel.getQuadKey()).to.be.equal(mockedQuadKey);
         expect(dataRequestWithTimemap.getVersion()).to.be.equal(mockedVersion);
+        expect(dataRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 
     it("Should get parameters with chain", () => {
@@ -73,11 +66,13 @@ describe("DataRequest", () => {
             .withDataHandle(mockedDataHandle)
             .withPartitionId(mockedPartitionId)
             .withQuadKey(mockedQuadKey)
-            .withVersion(mockedVersion);
+            .withVersion(mockedVersion)
+            .withBillingTag(billingTag);
 
         expect(dataRequest.getDataHandle()).to.be.equal(mockedDataHandle);
         expect(dataRequest.getPartitionId()).to.be.equal(mockedPartitionId);
         expect(dataRequest.getQuadKey()).to.be.equal(mockedQuadKey);
         expect(dataRequest.getVersion()).to.be.equal(mockedVersion);
+        expect(dataRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("PartitionsRequest", () => {
+    const billingTag = "billingTag";
     const mockedVersion = 42;
 
     it("Should initialize", () => {
@@ -40,20 +41,19 @@ describe("PartitionsRequest", () => {
 
     it("Should set parameters", () => {
         const partitionsRequest = new PartitionsRequest();
-        const partitionsRequestWithVersion = partitionsRequest.withVersion(
-            mockedVersion
-        );
+        const partitionsRequestWithVersion = partitionsRequest.withVersion(mockedVersion);
+        const partitionsRequestWithBillTag = partitionsRequest.withBillingTag(billingTag);
 
-        expect(partitionsRequestWithVersion.getVersion()).to.be.equal(
-            mockedVersion
-        );
+        expect(partitionsRequestWithVersion.getVersion()).to.be.equal(mockedVersion);
+        expect(partitionsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 
     it("Should get parameters with chain", () => {
-        const partitionsRequest = new PartitionsRequest().withVersion(
-            mockedVersion
-        );
+        const partitionsRequest = new PartitionsRequest()
+            .withVersion(mockedVersion)
+            .withBillingTag(billingTag);
 
         expect(partitionsRequest.getVersion()).to.be.equal(mockedVersion);
+        expect(partitionsRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/QuadTreeIndexRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QuadTreeIndexRequest.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { HRN, QuadTreeIndexRequest } from "../../lib";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("QuadTreeIndexRequest", () => {
+    const billingTag = "billingTag";
+    const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
+    const mockedLayerId = "mocked-layed-id";
+    const mockedVersion = 42;
+    const mockedLayerType = "volatile";
+    const mockedDepth = 3;
+    const mockedQuadKey = {
+        row: 1,
+        column: 2,
+        level: 3
+    };
+
+    it("Should initialize", () => {
+        const quadTreeRequest = new QuadTreeIndexRequest(
+            mockedHRN,
+            mockedLayerId,
+            mockedLayerType
+        );
+
+        assert.isDefined(quadTreeRequest);
+        expect(quadTreeRequest).be.instanceOf(QuadTreeIndexRequest);
+        expect(quadTreeRequest.getCatalogHrn()).to.be.equal(mockedHRN);
+        expect(quadTreeRequest.getLayerId()).to.be.equal(mockedLayerId);
+        expect(quadTreeRequest.getLayerType()).to.be.equal(mockedLayerType);
+    });
+
+    it("Should set parameters", () => {
+        const quadTreeRequest = new QuadTreeIndexRequest(
+            mockedHRN,
+            mockedLayerId,
+            mockedLayerType
+        );
+        const quadTreeRequestWithVersion = quadTreeRequest.withVersion(mockedVersion);
+        const quadTreeRequestWithQuadKey = quadTreeRequest.withQuadKey(mockedQuadKey);
+        const quadTreeRequestWithBillTag = quadTreeRequest.withBillingTag(billingTag);
+
+        expect(quadTreeRequestWithVersion.getVersion()).to.be.equal(mockedVersion);
+        expect(quadTreeRequestWithQuadKey.getQuadKey()).to.be.equal(mockedQuadKey);
+        expect(quadTreeRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
+    });
+
+    it("Should get parameters with chain", () => {
+        const quadTreeRequest = new QuadTreeIndexRequest(
+                mockedHRN,
+                mockedLayerId,
+                mockedLayerType
+            )
+            .withVersion(mockedVersion)
+            .withQuadKey(mockedQuadKey)
+            .withBillingTag(billingTag);
+
+        expect(quadTreeRequest.getVersion()).to.be.equal(mockedVersion);
+        expect(quadTreeRequest.getQuadKey()).to.be.equal(mockedQuadKey);
+        expect(quadTreeRequest.getBillingTag()).to.be.equal(billingTag);
+    });
+});

--- a/@here/olp-sdk-dataservice-read/test/unit/SchemaDetailsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SchemaDetailsRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("SchemaDetailsRequest", () => {
+    const billingTag = "billingTag";
     const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
 
     it("Should initialize", () => {
@@ -41,13 +42,25 @@ describe("SchemaDetailsRequest", () => {
     it("Should set parameters", () => {
         const schemaDetailsRequest = new SchemaDetailsRequest();
 
-        const schemaDetailsRequestWithVariant = schemaDetailsRequest.withSchema(
-            mockedHRN
-        );
+        const schemaDetailsRequestWithSchema = schemaDetailsRequest.withSchema(mockedHRN);
+        const schemaRequestWithBilTag = schemaDetailsRequest.withBillingTag(billingTag);
 
-        assert.isDefined(schemaDetailsRequestWithVariant);
-        expect(schemaDetailsRequestWithVariant.getSchema()).to.be.equal(
+        assert.isDefined(schemaDetailsRequestWithSchema);
+        assert.isDefined(schemaRequestWithBilTag);
+        expect(schemaDetailsRequestWithSchema.getSchema()).to.be.equal(
             mockedHRN
         );
+        expect(schemaRequestWithBilTag.getBillingTag()).to.be.equal(
+            billingTag
+        );
+    });
+
+    it("Should set parameters with chain", () => {
+        const schemaDetailsRequest = new SchemaDetailsRequest()
+            .withSchema(mockedHRN)
+            .withBillingTag(billingTag);
+
+        expect(schemaDetailsRequest.getSchema()).to.be.equal(mockedHRN);
+        expect(schemaDetailsRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/SchemaRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SchemaRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("SchemaRequest", () => {
+    const billingTag = "billingTag";
     const mockedVersion = {
         id: "42",
         url: "http://fake.url"
@@ -47,10 +48,24 @@ describe("SchemaRequest", () => {
         const schemaRequestWithVariant = schemaRequest.withVariant(
             mockedVersion
         );
+        const schemaRequestWithBilTag = schemaRequest.withBillingTag(billingTag);
 
         assert.isDefined(schemaRequestWithVariant);
+        assert.isDefined(schemaRequestWithBilTag);
         expect(schemaRequestWithVariant.getVariant()).to.be.equal(
             mockedVersion
         );
+        expect(schemaRequestWithBilTag.getBillingTag()).to.be.equal(
+            billingTag
+        );
+    });
+
+    it("Should set parameters with chain", () => {
+        const schemaRequest = new SchemaRequest()
+            .withVariant(mockedVersion)
+            .withBillingTag(billingTag);
+
+        expect(schemaRequest.getVariant()).to.be.equal(mockedVersion);
+        expect(schemaRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("SummaryRequest", () => {
+    const billingTag = "billingTag";
     const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
     const mockedLayerId = "mocked-layed-id";
     const mockedDataLevel = "42";
@@ -43,31 +44,17 @@ describe("SummaryRequest", () => {
 
     it("Should set parameters", () => {
         const statisticsRequest = new StatisticsRequest();
-        const statisticsRequestWithCatalogHrn = statisticsRequest.withCatalogHrn(
-            mockedHRN
-        );
-        const statisticsRequestWithLayerId = statisticsRequest.withLayerId(
-            mockedLayerId
-        );
-        const statisticsRequestWithDataLevel = statisticsRequest.withDataLevel(
-            mockedDataLevel
-        );
-        const statisticsRequestWithTimemap = statisticsRequest.withTypemap(
-            mockedTimemap
-        );
+        const statisticsRequestWithCatalogHrn = statisticsRequest.withCatalogHrn(mockedHRN);
+        const statisticsRequestWithLayerId = statisticsRequest.withLayerId(mockedLayerId);
+        const statisticsRequestWithDataLevel = statisticsRequest.withDataLevel(mockedDataLevel);
+        const statisticsRequestWithTimemap = statisticsRequest.withTypemap(mockedTimemap);
+        const statisticsRequestWithBillTag = statisticsRequest.withBillingTag(billingTag);
 
-        expect(statisticsRequestWithCatalogHrn.getCatalogHrn()).to.be.equal(
-            mockedHRN.toString()
-        );
-        expect(statisticsRequestWithLayerId.getLayerId()).to.be.equal(
-            mockedLayerId
-        );
-        expect(statisticsRequestWithDataLevel.getDataLevel()).to.be.equal(
-            mockedDataLevel
-        );
-        expect(statisticsRequestWithTimemap.getTypemap()).to.be.equal(
-            mockedTimemap
-        );
+        expect(statisticsRequestWithCatalogHrn.getCatalogHrn()).to.be.equal(mockedHRN.toString());
+        expect(statisticsRequestWithLayerId.getLayerId()).to.be.equal(mockedLayerId);
+        expect(statisticsRequestWithDataLevel.getDataLevel()).to.be.equal(mockedDataLevel);
+        expect(statisticsRequestWithTimemap.getTypemap()).to.be.equal(mockedTimemap);
+        expect(statisticsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 
     it("Should get parameters with chain", () => {
@@ -75,13 +62,13 @@ describe("SummaryRequest", () => {
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
             .withDataLevel(mockedDataLevel)
-            .withTypemap(mockedTimemap);
+            .withTypemap(mockedTimemap)
+            .withBillingTag(billingTag);
 
-        expect(statisticsRequest.getCatalogHrn()).to.be.equal(
-            mockedHRN.toString()
-        );
+        expect(statisticsRequest.getCatalogHrn()).to.be.equal(mockedHRN.toString());
         expect(statisticsRequest.getLayerId()).to.be.equal(mockedLayerId);
         expect(statisticsRequest.getDataLevel()).to.be.equal(mockedDataLevel);
         expect(statisticsRequest.getTypemap()).to.be.equal(mockedTimemap);
+        expect(statisticsRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/SummaryRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SummaryRequest.test.ts
@@ -29,6 +29,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("SummaryRequest", () => {
+    const billingTag = "billingTag";
     const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
     const mockedLayerId = "mocked-layed-id";
 
@@ -47,6 +48,7 @@ describe("SummaryRequest", () => {
         const summaryRequestWithLAyerId = summaryRequest.withLayerId(
             mockedLayerId
         );
+        const summaryRequestWithBillTag = summaryRequest.withBillingTag(billingTag);
 
         expect(summaryRequestWithCatalogHrn.getCatalogHrn()).to.be.equal(
             mockedHRN.toString()
@@ -54,16 +56,21 @@ describe("SummaryRequest", () => {
         expect(summaryRequestWithLAyerId.getLayerId()).to.be.equal(
             mockedLayerId
         );
+        expect(summaryRequestWithBillTag.getBillingTag()).to.be.equal(
+            billingTag
+        );
     });
 
     it("Should get parameters with chain", () => {
         const summaryRequest = new SummaryRequest()
             .withCatalogHrn(mockedHRN)
-            .withLayerId(mockedLayerId);
+            .withLayerId(mockedLayerId)
+            .withBillingTag(billingTag);
 
         expect(summaryRequest.getCatalogHrn()).to.be.equal(
             mockedHRN.toString()
         );
         expect(summaryRequest.getLayerId()).to.be.equal(mockedLayerId);
+        expect(summaryRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });


### PR DESCRIPTION
* Replace BlobAPI with VolatileBlobAPI
* Add unit-tests for VolatileLayerClient
* Fix billingTag validator
* Add unit-tests for billingTag

Resolves: OLPEDGE-851, OLPEDGE-852
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>