### PR TITLE
Update VolatileLayerClient and coverage for dataservice-read

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/QuadKeyPartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QuadKeyPartitionsRequest.ts
@@ -65,6 +65,15 @@ export class QuadKeyPartitionsRequest {
     }
 
     /**
+     * Billing Tag is an optional free-form tag which is used for grouping billing records together.
+     * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
+     */
+    public withBillingTag(tag: string): QuadKeyPartitionsRequest {
+        this.billingTag = validateBillingTag(tag);
+        return this;
+    }
+
+    /**
      * The configured catalog version for the request
      */
     public getVersion(): number | undefined {
@@ -83,14 +92,6 @@ export class QuadKeyPartitionsRequest {
      */
     public getDepth(): QuadTreeIndexDepth {
         return this.depth || 0;
-    }
-
-    /**
-     * Billing Tag is an optional free-form tag which is used for grouping billing records together.
-     * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     */
-    public withBillingTag(tag: string) {
-        this.billingTag = validateBillingTag(tag);
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
@@ -73,7 +73,7 @@ export class QueryClient {
                 )
             ));
 
-        if (!catalogVersion) {
+        if (!catalogVersion && catalogVersion !== 0) {
             return Promise.reject(`Please provide correct catalog version`);
         }
 

--- a/@here/olp-sdk-dataservice-read/lib/client/StatisticsClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StatisticsClient.ts
@@ -57,7 +57,7 @@ export class StatisticsClient {
         }
         const coverageRequestBuilder = await this.getRequestBuilder(
             catalogHrn
-        ).catch(error => Promise.reject(new Error(error)));
+        ).catch(error => Promise.reject(error));
         return CoverageApi.getDataCoverageSummary(coverageRequestBuilder, {
             layerId
         }).catch(this.errorHandler);

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
@@ -132,6 +132,45 @@ describe("CatalogClient", () => {
         assert.isTrue(response.versions.length > 0);
     });
 
+    it("Should method getVersions provide data with startVersion parameters", async () => {
+        const mockedVersions: MetadataApi.VersionInfos = {
+            versions: [
+                {
+                    dependencies: [
+                        {
+                            direct: true,
+                            hrn: "mocked:::hrn",
+                            version: 42
+                        }
+                    ],
+                    timestamp: 13,
+                    version: 42
+                }
+            ]
+        };
+
+        getListVersionsStub.callsFake(
+            (builder: any, params: any): Promise<MetadataApi.VersionInfos> => {
+                return Promise.resolve(mockedVersions);
+            }
+        );
+        getVersionStub.callsFake(
+            (builder: any, params: any): Promise<MetadataApi.VersionResponse> => {
+                return Promise.resolve({version: 42});
+            }
+        );
+
+        const catalogRequest = new dataServiceRead.CatalogVersionRequest()
+            .withStartVersion(13);
+
+        const response = await catalogClient.getVersions(
+            (catalogRequest as unknown) as dataServiceRead.CatalogVersionRequest
+        );
+
+        assert.isDefined(response);
+        assert.isTrue(response.versions.length > 0);
+    });
+
     it("Should method getCatalog provide data", async () => {
         const mockedCatalogResponse: ConfigApi.Catalog = {
             id: "here-internal-test",

--- a/@here/olp-sdk-dataservice-read/test/unit/QuadKeyPartitionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QuadKeyPartitionsRequest.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { QuadKeyPartitionsRequest } from "../../";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("QuadKeyPartitionsRequest", () => {
+    const billingTag = "billingTag";
+    const mockedVersion = 42;
+    const mockedDepth = 3;
+    const mockedQuadKey = {
+        row: 1,
+        column: 2,
+        level: 3
+    };
+
+    it("Should initialize", () => {
+        const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest();
+
+        assert.isDefined(quadKeyPartitionsRequest);
+        expect(quadKeyPartitionsRequest).be.instanceOf(QuadKeyPartitionsRequest);
+    });
+
+    it("Should set parameters", () => {
+        const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest();
+        const quadKeyPartitionsRequestWithVersion = quadKeyPartitionsRequest.withVersion(mockedVersion);
+        const quadKeyPartitionsRequestWithDepth = quadKeyPartitionsRequest.withDepth(mockedDepth);
+        const quadKeyPartitionsRequestWithQuadKey = quadKeyPartitionsRequest.withQuadKey(mockedQuadKey);
+        const quadKeyPartitionsRequestWithBillTag = quadKeyPartitionsRequest.withBillingTag(billingTag);
+
+        expect(quadKeyPartitionsRequestWithVersion.getVersion()).to.be.equal(mockedVersion);
+        expect(quadKeyPartitionsRequestWithDepth.getDepth()).to.be.equal(mockedDepth);
+        expect(quadKeyPartitionsRequestWithQuadKey.getQuadKey()).to.be.equal(mockedQuadKey);
+        expect(quadKeyPartitionsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
+    });
+
+    it("Should get parameters with chain", () => {
+        const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest()
+            .withVersion(mockedVersion)
+            .withDepth(mockedDepth)
+            .withQuadKey(mockedQuadKey)
+            .withBillingTag(billingTag);
+
+        expect(quadKeyPartitionsRequest.getVersion()).to.be.equal(mockedVersion);
+        expect(quadKeyPartitionsRequest.getDepth()).to.be.equal(mockedDepth);
+        expect(quadKeyPartitionsRequest.getQuadKey()).to.be.equal(mockedQuadKey);
+        expect(quadKeyPartitionsRequest.getBillingTag()).to.be.equal(billingTag);
+    });
+});

--- a/@here/olp-sdk-dataservice-read/test/unit/QuadTreeIndexRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QuadTreeIndexRequest.test.ts
@@ -21,7 +21,7 @@ import sinon = require("sinon");
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-import { HRN, QuadTreeIndexRequest } from "../../lib";
+import * as dataServiceRead from "../../lib";
 
 chai.use(sinonChai);
 
@@ -30,7 +30,7 @@ const expect = chai.expect;
 
 describe("QuadTreeIndexRequest", () => {
     const billingTag = "billingTag";
-    const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
+    const mockedHRN = dataServiceRead.HRN.fromString("hrn:here:data:::mocked-hrn");
     const mockedLayerId = "mocked-layed-id";
     const mockedVersion = 42;
     const mockedLayerType = "volatile";
@@ -42,21 +42,21 @@ describe("QuadTreeIndexRequest", () => {
     };
 
     it("Should initialize", () => {
-        const quadTreeRequest = new QuadTreeIndexRequest(
+        const quadTreeRequest = new dataServiceRead.QuadTreeIndexRequest(
             mockedHRN,
             mockedLayerId,
             mockedLayerType
         );
 
         assert.isDefined(quadTreeRequest);
-        expect(quadTreeRequest).be.instanceOf(QuadTreeIndexRequest);
+        expect(quadTreeRequest).be.instanceOf(dataServiceRead.QuadTreeIndexRequest);
         expect(quadTreeRequest.getCatalogHrn()).to.be.equal(mockedHRN);
         expect(quadTreeRequest.getLayerId()).to.be.equal(mockedLayerId);
         expect(quadTreeRequest.getLayerType()).to.be.equal(mockedLayerType);
     });
 
     it("Should set parameters", () => {
-        const quadTreeRequest = new QuadTreeIndexRequest(
+        const quadTreeRequest = new dataServiceRead.QuadTreeIndexRequest(
             mockedHRN,
             mockedLayerId,
             mockedLayerType
@@ -71,7 +71,7 @@ describe("QuadTreeIndexRequest", () => {
     });
 
     it("Should get parameters with chain", () => {
-        const quadTreeRequest = new QuadTreeIndexRequest(
+        const quadTreeRequest = new dataServiceRead.QuadTreeIndexRequest(
                 mockedHRN,
                 mockedLayerId,
                 mockedLayerType

--- a/@here/olp-sdk-dataservice-read/test/unit/QueryClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QueryClient.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import sinon = require("sinon");
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import * as dataServiceRead from "../../lib";
+import { MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("StatistiscClient", () => {
+    let sandbox: sinon.SinonSandbox;
+    let getVersionStub: sinon.SinonStub;
+    let quadTreeIndexVolatileStub: sinon.SinonStub;
+    let olpClientSettingsStub: sinon.SinonStubbedInstance<
+        dataServiceRead.OlpClientSettings
+    >;
+
+    let getBaseUrlRequestStub: sinon.SinonStub;
+    const mockedHRN = dataServiceRead.HRN.fromString("hrn:here:data:::mocked-hrn");
+    const mockedLayerId = "mocked-layed-id";
+    const mockedLayerType = "volatile";
+    const fakeURL = "http://fake-base.url";
+    const mockedQuadKey = {
+        row: 1,
+        column: 2,
+        level: 3
+    };
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    beforeEach(() => {
+        olpClientSettingsStub = sandbox.createStubInstance(
+            dataServiceRead.OlpClientSettings
+        );
+        quadTreeIndexVolatileStub = sandbox.stub(QueryApi, "quadTreeIndexVolatile");
+        getVersionStub = sandbox.stub(MetadataApi, "latestVersion");
+        getBaseUrlRequestStub = sandbox.stub(
+            dataServiceRead.RequestFactory,
+            "getBaseUrl"
+        );
+
+        getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("Shoud be initialised with settings", async () => {
+        const queryClient = new dataServiceRead.QueryClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(queryClient);
+    });
+
+    it("Should method fetchQuadTreeIndex provide data with all parameters", async () => {
+        const mockedQuadKeyTreeData = {
+            subQuads: [
+                {
+                    version: 12,
+                    subQuadKey: "1",
+                    dataHandle: "c9116bb9-7d00-44bf-9b26-b4ab4c274665"
+                }
+            ],
+            parentQuads: [
+                {
+                    version: 12,
+                    partition: "23618403",
+                    dataHandle: "da51785a-54b0-40cd-95ac-760f56fe5457"
+                }
+            ]
+        };
+        const queryClient = new dataServiceRead.QueryClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(queryClient);
+
+        quadTreeIndexVolatileStub.callsFake(
+            (builder: any, params: any): Promise<QueryApi.Index> => {
+                return Promise.resolve(mockedQuadKeyTreeData);
+            }
+        );
+
+        const quadTreeIndexRequest = new dataServiceRead.QuadTreeIndexRequest(
+            mockedHRN,
+            mockedLayerId,
+            mockedLayerType
+        ).withQuadKey(mockedQuadKey).withVersion(42);
+
+        const response = await queryClient.fetchQuadTreeIndex(quadTreeIndexRequest)
+
+        assert.isDefined(response);
+        expect(response).to.be.equal(mockedQuadKeyTreeData);
+    });
+
+    it("Should method fetchQuadTreeIndex return error if quadKey is not provided", async () => {
+        const mockedErrorResponse = "Please provide correct QuadKey";
+        const queryClient = new dataServiceRead.QueryClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(queryClient);
+
+        const quadTreeIndexRequest = new dataServiceRead.QuadTreeIndexRequest(
+            mockedHRN,
+            mockedLayerId,
+            mockedLayerType
+        );
+
+        const result = await queryClient.fetchQuadTreeIndex(quadTreeIndexRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error);
+            });
+    });
+
+    it("Should method fetchQuadTreeIndex return error if layerId is not provided", async () => {
+        const mockedErrorResponse = "Please provide correct Id of the Layer";
+        const queryClient = new dataServiceRead.QueryClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(queryClient);
+
+        const quadTreeIndexRequest = new dataServiceRead.QuadTreeIndexRequest(
+            mockedHRN,
+            "",
+            mockedLayerType
+        ).withQuadKey(mockedQuadKey);
+
+        const result = await queryClient.fetchQuadTreeIndex(quadTreeIndexRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error);
+            });
+    });
+
+    it("Should method fetchQuadTreeIndex return error if catalog version is not provided", async () => {
+        const mockedErrorResponse = `Please provide correct catalog version`;
+        const queryClient = new dataServiceRead.QueryClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(queryClient);
+
+        getVersionStub.callsFake(
+            (builder: any, params: any): Promise<MetadataApi.VersionResponse> => {
+                return Promise.resolve({version: NaN});
+            }
+        );
+
+        const quadTreeIndexRequest = new dataServiceRead.QuadTreeIndexRequest(
+            mockedHRN,
+            mockedLayerId,
+            mockedLayerType
+        ).withQuadKey(mockedQuadKey);
+
+        const result = await queryClient.fetchQuadTreeIndex(quadTreeIndexRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error);
+            });
+    });
+
+    it("Should method fetchQuadTreeIndex return error if catalog version is not provided", async () => {
+        const mockedError = "Unknown error";
+        const mockedErrorResponse = `Error getting the last catalog version: ${mockedError}`;
+        const queryClient = new dataServiceRead.QueryClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(queryClient);
+
+        getVersionStub.callsFake(
+            (builder: any, params: any): Promise<MetadataApi.VersionResponse> => {
+                return Promise.reject(mockedError);
+            }
+        );
+
+        const quadTreeIndexRequest = new dataServiceRead.QuadTreeIndexRequest(
+            mockedHRN,
+            mockedLayerId,
+            mockedLayerType
+        ).withQuadKey(mockedQuadKey);
+
+        const result = await queryClient.fetchQuadTreeIndex(quadTreeIndexRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error);
+            });
+    });
+});

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
@@ -127,6 +127,40 @@ describe("StatistiscClient", () => {
         assert.isDefined(summary);
     });
 
+    it("Should method getSummary return error if catalogHRN is not provided", async () => {
+        const mockedErrorResponse = "No catalogHrn provided";
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(statisticsClient);
+
+        const summaryRequest = new dataServiceRead.SummaryRequest()
+            .withLayerId(mockedLayerId);
+
+        const summary = await statisticsClient.getSummary(summaryRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.message);
+            });
+    });
+
+    it("Should method getSummary return error if layerId is not provided", async () => {
+        const mockedErrorResponse = "No layerId provided";
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(statisticsClient);
+
+        const summaryRequest = new dataServiceRead.SummaryRequest()
+            .withCatalogHrn(mockedHRN);
+
+        const summary = await statisticsClient.getSummary(summaryRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.message);
+            });
+    });
+
     it("Should method getStatistics provide data", async () => {
         const mockedStatistics: Response = new Response("mocked-response");
         const statisticsClient = new dataServiceRead.StatisticsClient(
@@ -181,5 +215,85 @@ describe("StatistiscClient", () => {
             statisticTimeMapRequest
         );
         assert.isDefined(statisticTimeMap);
+    });
+
+    it("Should method getStatistics return error if catalogHRN is not provided", async () => {
+        const mockedErrorResponse = "No catalogHrn provided";
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(statisticsClient);
+
+        const statisticRequest = new dataServiceRead.StatisticsRequest()
+            .withLayerId(mockedLayerId)
+            .withDataLevel("12")
+            .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
+
+        const statistic = await statisticsClient.getStatistics(
+            statisticRequest
+        ).catch(error => {
+            assert.isDefined(error);
+            assert.equal(mockedErrorResponse, error.message);
+        });
+    });
+
+    it("Should method getStatistics return error if layerId is not provided", async () => {
+        const mockedErrorResponse = "No layerId provided";
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(statisticsClient);
+
+        const statisticRequest = new dataServiceRead.StatisticsRequest()
+            .withCatalogHrn(mockedHRN)
+            .withDataLevel("12")
+            .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
+
+        const statistic = await statisticsClient.getStatistics(
+            statisticRequest
+        ).catch(error => {
+            assert.isDefined(error);
+            assert.equal(mockedErrorResponse, error.message);
+        });
+    });
+
+    it("Should method getStatistics return error if dataLevel is not provided", async () => {
+        const mockedErrorResponse = "No dataLevel provided";
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(statisticsClient);
+
+        const statisticRequest = new dataServiceRead.StatisticsRequest()
+            .withCatalogHrn(mockedHRN)
+            .withLayerId(mockedLayerId)
+            .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
+
+        const statistic = await statisticsClient.getStatistics(
+            statisticRequest
+        ).catch(error => {
+            assert.isDefined(error);
+            assert.equal(mockedErrorResponse, error.message);
+        });
+    });
+
+    it("Should method getStatistics return error if typemap is not provided", async () => {
+        const mockedErrorResponse = "No typemap provided";
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(statisticsClient);
+
+        const statisticRequest = new dataServiceRead.StatisticsRequest()
+            .withCatalogHrn(mockedHRN)
+            .withLayerId(mockedLayerId)
+            .withDataLevel("12");
+
+        const statistic = await statisticsClient.getStatistics(
+            statisticRequest
+        ).catch(error => {
+            assert.isDefined(error);
+            assert.equal(mockedErrorResponse, error.message);
+        });
     });
 });


### PR DESCRIPTION
* Add unit-tests
* Update unit-tests
* Update coverage for dataservice-read module

Resolves: OLPEDGE-851, OLPEDGE-852
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>