### PR TITLE
Fixed headings hierarchy and modified examples

### DIFF
--- a/@here/olp-sdk-authentication/README.md
+++ b/@here/olp-sdk-authentication/README.md
@@ -1,14 +1,16 @@
-# Overview
+# Authentification library
 
-This repository contains all required methods and classes to request access token for OAuth authentication.
+## Overview
+
+This repository contains all required methods and classes to request an access token for OAuth authentication.
 
 ## UserAuth
 
-## Description
+### Description
 
 UserAuth class instance is used to obtain client token by providing authentication data.
 
-## Configuration
+### Configure
 
 Creating an instance of UserAuth class requires configuration object to be passed to the constructor:
 
@@ -16,7 +18,7 @@ Creating an instance of UserAuth class requires configuration object to be passe
 const auth = new UserAuth(config);
 ```
 
-## Usage with local authorization
+### Use with Local Authorization
 
 Create an instance of UserAuth class before instantiating any data sources:
 
@@ -54,8 +56,9 @@ Get token:
 const token: string = await userAuth.getToken();
  ```
 
-## Usage with import credentials from file
-Download your credentials.properties file from [OLP website](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html).
+### Use with Credentials Imported from a File
+
+Download your **credentials.properties** file from the [OLP website](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html).
 Create an instance of UserAuth class and set the path to the file with credentials:
 
 ```typescript
@@ -81,7 +84,7 @@ Get token:
 const token: string = await userAuth.getToken();
 ```
 
-## Usage of Bundle functionality:
+### Generate a Bundle
 
 If you want to have a compiled project, you can use bundle commands. After running each of the following commands in the `@here/olp-sdk-authentication/dist/bundle` folder from the root folder, you get the JavaScript bundled files.
 
@@ -103,7 +106,7 @@ To get bundled and minified JavaScript files, run:
 npm run prepublish-bundle
 ```
 
-## Simple bundle
+### Use a Bundle from CDN
 
 Add minified JavaScript file to your `html` and create an object of userAuth:
 
@@ -111,6 +114,7 @@ Add minified JavaScript file to your `html` and create an object of userAuth:
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="https://unpkg.com/@here/olp-sdk-fetch/bundle.umd.min.js"></script>
     <script src="https://unpkg.com/@here/olp-sdk-authentication/bundle.umd.min.js"></script>
 </head>
 <body>
@@ -123,7 +127,6 @@ Add minified JavaScript file to your `html` and create an object of userAuth:
         },
         tokenRequester: requestToken
     });
-
         userAuth.getToken().then(token => {
             // your token here
         });

--- a/@here/olp-sdk-dataservice-api/README.md
+++ b/@here/olp-sdk-dataservice-api/README.md
@@ -1,11 +1,10 @@
-# Generated DataStore API
+# DataService API Library
 
-# Overview
+## Overview
 
 This API is generated directly from the official OpenAPI (former Swagger) definition of the [HERE Open Location Platform Data API](https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html).
 
-
-## Usage of Bundle functionality
+## Generate a Bundle
 
 If you want to have a compiled project, you can use bundle commands. After running each of the following commands in the `dist/@here/olp-sdk-dataservice-api/bundle` folder from the root folder, you get the JavaScript bundled files.
 
@@ -27,7 +26,7 @@ To get bundled and minified JavaScript files, run:
 npm run prepublish-bundle
 ```
 
-## Simple bundle
+## Use a Bundle from CDN
 
 Add minified JavaScript files to your `html`:
 

--- a/@here/olp-sdk-dataservice-read/README.md
+++ b/@here/olp-sdk-dataservice-read/README.md
@@ -1,10 +1,10 @@
-# DataStore Access Library
+# DataService Access Library
 
-# Overview
+## Overview
 
 This repository contains the complete source code for the HERE OLP SDK for TypeScript Dataservice Read `@here/olp-sdk-dataservice-read` project. `olp-sdk-dataservice-read` is a TypeScript library that will fetch request Layer and Partition data from the OLP catalogs.
 
-# Directory Layout
+## Directory Layout
 
 Here is an overview of the top-level files of the repository:
 
@@ -15,16 +15,16 @@ Here is an overview of the top-level files of the repository:
                         |
                         +- test   # Test code
 
-# Development
+## Development
 
-## Prerequisites
+### Prerequisites
 
 The following NPM packages are required to build/test the library:
 
     - node: >= 10.0.0
     - npm: >= 6.0.0
 
-## Building
+### Build
 
 Open a command prompt of the working tree's root directory and type:
 
@@ -33,7 +33,7 @@ npm install
 npm run build
 ```
 
-## Testing
+### Test
 
 Open a command prompt of the working tree's root directory and type:
 
@@ -41,7 +41,7 @@ Open a command prompt of the working tree's root directory and type:
 npm run test
 ```
 
-## Usage of Bundle functionality
+### Generate a Bundle
 
 If you want to have a compiled project, you can use bundle commands. After running each of the following commands in the `@here/olp-sdk-dataservice-read/dist/bundle` folder from the root folder, you get the JavaScript bundled files.
 
@@ -63,7 +63,7 @@ To get bundled and minified JavaScript files, run:
 npm run prepublish-bundle
 ```
 
-## Simple bundle
+### Use a Bundle from CDN
 
 Add minified JavaScript files to your `html` and create an object of userAuth and catalogClient:
 
@@ -89,7 +89,6 @@ Add minified JavaScript files to your `html` and create an object of userAuth an
         },
         tokenRequester: requestToken
     });
-
     /**
      * Create DatastoreContext with olp-sdk-dataservice-read
      */
@@ -97,7 +96,6 @@ Add minified JavaScript files to your `html` and create an object of userAuth an
         environment: "here",
         getToken: () => userAuth.getToken()
     });
-
     /**
      * Create client to the volatile layer with olp-sdk-dataservice-read
      */
@@ -106,7 +104,6 @@ Add minified JavaScript files to your `html` and create an object of userAuth an
         hrn: "your-catalog-hrn",
         layerId: "your-layer-id",
     });
-
     /**
      * Get some partition from the layer by ID
      */

--- a/@here/olp-sdk-fetch/README.md
+++ b/@here/olp-sdk-fetch/README.md
@@ -1,4 +1,4 @@
-# @here/olp-sdk-fetch
+# Fetch Library
 
 ## Overview
 
@@ -18,11 +18,11 @@ import "@here/olp-sdk-fetch"
 
 This adds `fetch` to the global `Node.js` namespace.
 
-## Behavior in Browser Context
+## Behavior in a Browser Context
 
 When this module is used in a browser context, it does not perform any actions, nor adds any code.
 
-## Usage of Bundle functionality:
+## Generate a Bundle
 
 If you want to have a compiled project, you can use bundle commands. After running each of the following commands in the `@here/olp-sdk-fetch/dist/bundle` folder from the root folder, you get the JavaScript bundled files.
 
@@ -39,8 +39,24 @@ npm run bundle:prod
 ```
 
 To get a bundled and minified JavaScript files, run:
+
 ```sh
 npm run prepublish-bundle
+```
+
+## Use a Bundle from CDN
+
+Add minified JavaScript file to your `html` and create an object of userAuth:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script src="https://unpkg.com/@here/olp-sdk-fetch/bundle.umd.min.js"></script>
+</head>
+<body>
+</body>
+</html>
 ```
 
 ## LICENSE


### PR DESCRIPTION
Fixed headings hierarchy and modified examples in the **Use a Bundle
from CDN** section in the following files:

* @here/olp-sdk-authentication/README.md
* @here/olp-sdk-dataservice-api/README.md
* @here/olp-sdk-dataservice-read/README.md
* @here/olp-sdk-fetch/README.md

Relates-to: OLPEDGE-1138

Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>