### PR TITLE
Get earliest version by Catalog Client.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
@@ -74,7 +74,34 @@ export class CatalogClient {
     }
 
     /**
-     * Get the latest version of the catalog.
+     * Returns minimum version for the given catalog. If the catalog doesn't contain any versions error will be returned.
+     * @param request Is [[CatalogVersionRequest]] instance and has ((getBillingTag)) method.
+     * @param abortSignal A signal object that allows you to communicate with a request (such as a Fetch)
+     * and abort it if required via an AbortController object.
+     *  @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     *  @returns A promise of the http response that contains the pminimum version for the given catalog.
+     */
+    public async getEarliestVersion(
+        request: CatalogVersionRequest,
+        abortSignal?: AbortSignal
+    ): Promise<MetadataApi.VersionResponse> {
+        const builder = await this.getRequestBuilder(
+            "metadata",
+            HRN.fromString(this.hrn),
+            abortSignal
+        ).catch(error => Promise.reject(error));        
+
+        const earliestVersion = await MetadataApi.minimumVersion(
+            builder,
+            {
+                billingTag: request.getBillingTag()
+            }
+        ).catch(err => Promise.reject(`Error getting earliest catalog version: ${err}`));
+
+        return Promise.resolve(earliestVersion);
+    }
+
+    /* Get the latest version of the catalog.
      *
      * @param request Is [[CatalogVersionRequest]] instance and has ((getStartVersion)) method to get startVersion.
      * Catalog start version (exclusive). Default is -1. By convention -1

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
@@ -34,6 +34,7 @@ describe("CatalogClient", () => {
     let getVersionStub: sinon.SinonStub;
     let getCatalogStub: sinon.SinonStub;
     let getListVersionsStub: sinon.SinonStub;
+    let getEarliestVersionsStub: sinon.SinonStub;
     let catalogClient: dataServiceRead.CatalogClient;
     let getBaseUrlRequestStub: sinon.SinonStub;
     const fakeURL = "http://fake-base.url";
@@ -56,6 +57,7 @@ describe("CatalogClient", () => {
         getVersionStub = sandbox.stub(MetadataApi, "latestVersion");
         getCatalogStub = sandbox.stub(ConfigApi, "getCatalog");
         getListVersionsStub = sandbox.stub(MetadataApi, "listVersions");
+        getEarliestVersionsStub = sandbox.stub(MetadataApi, "minimumVersion");
         getBaseUrlRequestStub = sandbox.stub(
             dataServiceRead.RequestFactory,
             "getBaseUrl"
@@ -130,6 +132,32 @@ describe("CatalogClient", () => {
 
         assert.isDefined(response);
         assert.isTrue(response.versions.length > 0);
+    });
+
+    it("Should method getEarliestVersion provide the minimun version availiable for the given catalogRequest", async () => {
+        const testBillingTag =  "testBillingTag";
+        const mockedEarliestVersion: MetadataApi.VersionResponse = {
+            version: 5
+        };
+
+        getEarliestVersionsStub.callsFake(
+            (
+                builder: any,
+                params: any
+            ): Promise<MetadataApi.VersionResponse> => {
+                return Promise.resolve(mockedEarliestVersion);
+            }
+        );
+
+        const catalogRequest = new dataServiceRead.CatalogVersionRequest().withBillingTag(
+            testBillingTag
+        );        
+        const response = await catalogClient.getEarliestVersion(
+            (catalogRequest as unknown) as dataServiceRead.CatalogVersionRequest
+        );
+
+        assert.isDefined(response);
+        expect(response).to.be.equal(mockedEarliestVersion);
     });
 
     it("Should method getVersions provide data with startVersion parameters", async () => {


### PR DESCRIPTION
* Update CatalogVersionRequest class.

* Get earliest version by Catalog Client.

* Update Unit tests.

Relates-To: OLPEDGE-918.

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>