### PR TITLE
Add skeleton for integration testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,16 @@ npm run build
 
 #### Test the SDK
 
-To test the built results, run the following command:
+To test the built results with unit tests, run the following command:
 
 ```sh
 npm run test
+```
+
+To test the built results with integration tests, run the following command:
+
+```sh
+npm run integration-test
 ```
 
 #### Test Coverage

--- a/package.json
+++ b/package.json
@@ -11,10 +11,29 @@
   "workspaces": [
     "@here/*"
   ],
+  "nyc": {
+    "include": [
+      "@here/**/*.ts",
+      "@here/**/*.js"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "text",
+      "html"
+    ],
+    "sourceMap": true,
+    "instrument": true
+  },
   "scripts": {
     "bootstrap": "lerna bootstrap --use-workspaces",
     "build": "lerna run build",
     "test": "lerna run test",
+    "integration-test": "nyc mocha --opts ./tests/integration/mocha.opts > xunit.xml",
     "coverage": "lerna run coverage",
     "lint": "lerna run lint",
     "bundle": "lerna run bundle",

--- a/scripts/linux/psv/travis_build_test_psv.sh
+++ b/scripts/linux/psv/travis_build_test_psv.sh
@@ -37,4 +37,7 @@ npm run test
 # generate test coverage
 npm run coverage
 
+# Integration tests
+npm run integration-test
+
 

--- a/tests/integration/VersionedLayerClient.test.ts
+++ b/tests/integration/VersionedLayerClient.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as sinon from "sinon";
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import { VersionedLayerClient, OlpClientSettings, HRN, PartitionsRequest } from "@here/olp-sdk-dataservice-read";
+import { fetchMock } from "./fetchMock";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+
+describe("VersionedLayerClient", () => {
+
+    let sandbox: sinon.SinonSandbox;
+    let fetchStub: sinon.SinonStub;
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    beforeEach(() => {
+        fetchStub = sandbox.stub(global as any, "fetch");
+        fetchStub.callsFake(fetchMock);
+    });
+
+    it("Shoud be initialised with settings", async () => {
+        const settings = new OlpClientSettings({
+            environment: "here",
+            "getToken": () => Promise.resolve("test-token-string")
+        });
+        const layerClient = new VersionedLayerClient(HRN.fromString("hrn:here:data:::test-hrn"), "test-layed-id", settings);
+        assert.isDefined(layerClient);
+        expect(layerClient).to.be.instanceOf(VersionedLayerClient);
+    });
+
+    it("Shoud be fetched partitions metadata for specific IDs", async () => {
+        const settings = new OlpClientSettings({
+            environment: "here",
+            "getToken": () => Promise.resolve("test-token-string")
+        });
+        const layerClient = new VersionedLayerClient(HRN.fromString("hrn:here:data:::test-hrn"), "test-layed-id", settings);
+        const request = new PartitionsRequest().withPartitionIds(["100", "1000"]);
+
+        const partitions = await layerClient.getPartitions(request);
+        assert.isDefined(partitions);
+
+        expect(partitions.partitions[0].dataHandle).to.be.equal("1b2ca68f-d4a0-4379-8120-cd025640510c");
+        expect(partitions.partitions[1].dataHandle).to.be.equal("1b2ca68f-d4a0-4379-8120-cd025640578e");
+        expect(partitions.partitions[2]).to.be.undefined;
+    });
+
+    it("Shoud be fetched partitions all metadata", async () => {
+        const settings = new OlpClientSettings({
+            environment: "here",
+            "getToken": () => Promise.resolve("test-token-string")
+        });
+        const layerClient = new VersionedLayerClient(HRN.fromString("hrn:here:data:::test-hrn"), "test-layed-id", settings);
+        const request = new PartitionsRequest();
+
+        const partitions = await layerClient.getPartitions(request);
+        assert.isDefined(partitions);
+
+        expect(partitions.partitions[0].dataHandle).to.be.equal("1b2ca68f-d4a0-4379-8120-cd025640510c");
+        expect(partitions.partitions[1].dataHandle).to.be.equal("1b2ca68f-d4a0-4379-8120-cd025640578e");
+        expect(partitions.partitions.length).to.be.equal(4);
+    });
+
+
+});
+

--- a/tests/integration/fetchMock.ts
+++ b/tests/integration/fetchMock.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/**
+ * A `fetch` implementation for e2e testing.
+ *
+ * *Use only for testing purposes*.
+ *
+ * Example:
+ * ```
+ *     const fetchStub = sandbox.stub(global as any, "fetch");
+ *     fetchStub.callsFake(mockedFetch);
+ *     await someApi.loadSomethingWithFetch("https://example.com");
+ *     assert.equal(fetchStub, 1);
+ * ```
+ *
+ * @see [fetch documentation](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+ */
+export async function fetchMock
+(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<Response> {
+  const url = typeof input === "object" ? input.url : input;
+  console.log("Requested url: " + url);
+  let result: string;
+  switch (url) {
+    case "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::test-hrn/apis/query/v1":
+
+    result = JSON.stringify([
+        {
+          api: "query",
+          version: "v1",
+          baseURL: "https://query.data.api.platform.here.com/query/v1",
+          parameters: {
+            additionalProp1: "string",
+            additionalProp2: "string",
+            additionalProp3: "string"
+          }
+        }
+      ]);
+
+      break;
+
+    case "https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/partitions?partition=100&partition=1000":
+
+            result = JSON.stringify({
+                "partitions": [
+                  {
+                    "checksum": "291f66029c232400e3403cd6e9cfd36e",
+                    "compressedDataSize": 1024,
+                    "dataHandle": "1b2ca68f-d4a0-4379-8120-cd025640510c",
+                    "dataSize": 1024,
+                    "crc": "c3f276d7",
+                    "partition": "100",
+                    "version": 2
+                  },
+                  {
+                    "checksum": "123f66029c232400e3403cd6e9cfd45b",
+                    "compressedDataSize": 2084,
+                    "dataHandle": "1b2ca68f-d4a0-4379-8120-cd025640578e",
+                    "dataSize": 2084,
+                    "crc": "c3f2766y",
+                    "partition": "1000",
+                    "version": 2
+                  }
+                ]
+              });
+
+        break;
+
+    case "https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::test-hrn/apis/metadata/v1":
+
+              result = JSON.stringify([{
+                api: "metadata",
+                version: "v1",
+                baseURL: "https://metadata.data.api.platform.here.com/metadata/v1",
+                parameters: {
+                  additionalProp1: "string",
+                  additionalProp2: "string",
+                  additionalProp3: "string"
+                }
+              }]);
+    break;
+
+    case "https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1":
+            result = JSON.stringify({"version": 128});
+    break;
+
+    case "https://metadata.data.api.platform.here.com/metadata/v1/layers/test-layed-id/partitions?version=128":
+            result = JSON.stringify({
+                "partitions": [
+                  {
+                    "checksum": "291f66029c232400e3403cd6e9cfd36e",
+                    "compressedDataSize": 1024,
+                    "dataHandle": "1b2ca68f-d4a0-4379-8120-cd025640510c",
+                    "dataSize": 1024,
+                    "crc": "c3f276d7",
+                    "partition": "314010583",
+                    "version": 1
+                  },
+                  {
+                    "checksum": "123f66029c232400e3403cd6e9cfd45b",
+                    "compressedDataSize": 2084,
+                    "dataHandle": "1b2ca68f-d4a0-4379-8120-cd025640578e",
+                    "dataSize": 2084,
+                    "crc": "c3f2766y",
+                    "partition": "1000",
+                    "version": 2
+                  },
+                  {
+                    "checksum": "123f66029c232400e3403cd6e9cfd345",
+                    "compressedDataSize": 2084,
+                    "dataHandle": "1b2ca68f-d4a0-4379-8120-cd0256405444",
+                    "dataSize": 2084,
+                    "crc": "c3f2766y",
+                    "partition": "1000",
+                    "version": 2
+                  },{
+                    "checksum": "123f66029c232400e3403cd6e9cfd234",
+                    "compressedDataSize": 2084,
+                    "dataHandle": "1b2ca68f-d4a0-4379-8120-cd0256405555",
+                    "dataSize": 2084,
+                    "crc": "c3f2766y",
+                    "partition": "1000",
+                    "version": 2
+                  }
+                ],
+                "next": "/uri/to/next/page"
+              });
+
+        break;
+
+    default:
+      throw new Error(`Unhandled URL: ${url}`);
+  }
+
+  const response = new Response(result);
+
+  return new Promise((resolve, reject) => {
+    resolve(response);
+  });
+}

--- a/tests/integration/mocha.opts
+++ b/tests/integration/mocha.opts
@@ -1,0 +1,7 @@
+--require  ts-node/register
+--require source-map-support/register
+--full-trace
+--bail
+--check-leaks
+--reporter xunit
+tests/integration/*.test.ts


### PR DESCRIPTION
- Add three simple tests for Versioned Layer Client to testing functionality of components.
- Add mocked fetch, replaced fetch from Global scope and used for returning mocked responses for requests.
- Setup coverage for integration testing

Relates-To: OLPEDGE-845
Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>