### PR TITLE
Add Travis job and script for NPM publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,15 @@ cache: yarn
 env:
   global:
   - WORKSPACE=$TRAVIS_BUILD_DIR
-name: Linux Xenial Build and Test
-script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh
 branches:
-  only:
-  - master
+    only:
+      - master
+name: "PSV Linux Build & Test"
+script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh
+deploy:
+  - provider: script
+    script: $WORKSPACE/scripts/publish-packages.sh
+    skip_cleanup: true
+    on:
+      tags: true
+      branch: master

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+#Simple script that bundles the publishing of packages
+#to be run from Travis
+
+echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
+#npx lerna publish -y from-git --pre-dist-tag alpha
+echo "Fake publish"


### PR DESCRIPTION
Job will trigger on tag creation.
Script require NPM_TOKEN to be defined as variable.

Relates-To: OLPEDGE-895

Signed-off-by: Yaroslav Stefinko <ystefinko@intellias.com>