### PR TITLE
CatalogClient.ts fix to have identical return type for get earliest version and get later version methods

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
@@ -93,7 +93,7 @@ export class CatalogClient {
     public async getEarliestVersion(
         request: CatalogVersionRequest,
         abortSignal?: AbortSignal
-    ): Promise<MetadataApi.VersionResponse> {
+    ): Promise<number> {
         const builder = await this.getRequestBuilder(
             "metadata",
             HRN.fromString(this.hrn),
@@ -106,7 +106,7 @@ export class CatalogClient {
             Promise.reject(`Error getting earliest catalog version: ${err}`)
         );
 
-        return Promise.resolve(earliestVersion);
+        return Promise.resolve(earliestVersion.version);
     }
 
     /**
@@ -195,7 +195,7 @@ export class CatalogClient {
             startVersion,
             billingTag: request.getBillingTag()
         });
-        return latestVersion.version;
+        return Promise.resolve(latestVersion.version);
     }
 
     /**


### PR DESCRIPTION
Added fix to have identical return type forEarliestVersion and getLatestVersion method