### PR TITLE
Update error handling for VersionedLayerClient and VolatileLayerClient

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/query-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/query-api.ts
@@ -37,12 +37,21 @@ export interface Index {
     /**
      * Result of the index resource call. For each parent tile, one element with the respective parent-quad data is contained in the array.
      */
-    parentQuads: ParentQuad[];
+    parentQuads?: ParentQuad[];
     /**
      * Result of the index resource call. For each tile that contains data in the requested quadKey,
      * one element with the respective sub-quad data is contained in the array.
      */
-    subQuads: SubQuad[];
+    subQuads?: SubQuad[];
+    /**
+     * Error code
+     */
+    status?: number;
+
+    /**
+     * Error description
+     */
+    title?: string;
 }
 
 export interface ParentQuad {
@@ -132,7 +141,17 @@ export interface Partition {
  * Describes a list of partitions for a given layer and layer version.
  */
 export interface Partitions {
-    partitions: Partition[];
+    partitions?: Partition[];
+
+    /**
+     * Error code
+     */
+    status?: number;
+
+    /**
+     * Error description
+     */
+    title?: string;
 }
 
 export interface SubQuad {

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -176,7 +176,7 @@ describe("VersionedLayerClient", () => {
         assert.isTrue(response.ok);
     });
 
-    it("Should method getData provide data with partitionId quadKey", async () => {
+    it("Should method getData provide data with quadKey", async () => {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedVersion = {
             version: 42
@@ -238,6 +238,66 @@ describe("VersionedLayerClient", () => {
             .catch(error => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error.message);
+            });
+    });
+
+    it("Should method getData return Error with correct partitionId and wrong version parameter", async () => {
+        const dataRequest = new dataServiceRead.DataRequest().withVersion(100500).withPartitionId(
+            "42"
+        );
+
+        const mockedPartitionsIdData = {
+            status: 400,
+            title: "Bad request",
+            detail: [
+                {
+                    name: "version",
+                    error: 'Invalid version: latest known version is 181'
+                }
+            ]
+        };
+
+        getPartitionsByIdStub.callsFake(
+            (builder: any, params: any): any => {
+                return Promise.resolve(mockedPartitionsIdData);
+            }
+        );
+
+        const response = await versionedLayerClient
+            .getData((dataRequest as unknown) as dataServiceRead.DataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(error, mockedPartitionsIdData);
+            });
+    });
+
+    it("Should method getData return Error with correct quadKey and wrong version parameter", async () => {
+        const dataRequest = new dataServiceRead.DataRequest().withVersion(100500).withQuadKey(
+            dataServiceRead.quadKeyFromMortonCode("23618403")
+        );
+
+        const mockedPartitionsIdData = {
+            status: 400,
+            title: "Bad request",
+            detail: [
+                {
+                    name: "version",
+                    error: 'Invalid version: latest known version is 181'
+                }
+            ]
+        };
+
+        getQuadTreeIndexStub.callsFake(
+            (builder: any, params: any): any => {
+                return Promise.resolve(mockedPartitionsIdData);
+            }
+        );
+
+        const response = await versionedLayerClient
+            .getData((dataRequest as unknown) as dataServiceRead.DataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(error, mockedPartitionsIdData);
             });
     });
 

--- a/tests/integration/VersionedLayerClient.test.ts
+++ b/tests/integration/VersionedLayerClient.test.ts
@@ -836,8 +836,8 @@ describe("VersionedLayerClient", () => {
         quadKeyPartitionsRequest
       );
   
-      expect(partitions.parentQuads[0].partition).to.be.equal(
-        "73982"
-      );
+    if (partitions.parentQuads) {
+        expect(partitions.parentQuads[0].partition).to.be.equal("73982");
+    }
     });
 });

--- a/tests/integration/VolatileLayerClient.test.ts
+++ b/tests/integration/VolatileLayerClient.test.ts
@@ -646,7 +646,8 @@ describe("VolatileLayerClient", () => {
     const partitions = await layerClient.getPartitions(
       quadKeyPartitionsRequest
     );
-
-    expect(partitions.parentQuads[0].partition).to.be.equal("73982");
+    if (partitions.parentQuads) {
+      expect(partitions.parentQuads[0].partition).to.be.equal("73982");
+    }
   });
 });


### PR DESCRIPTION
* Add error handler for incorrect version and layerId parameters for VersionedLayerClient
* Add error handler for incorrect layerId parameter for VersionedLayerClient
* Update unit-tests

Resolves: OLPSUP-8931
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>