### PR TITLE
Improve return data type for getEarliestVersion method.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
@@ -93,7 +93,7 @@ export class CatalogClient {
     public async getEarliestVersion(
         request: CatalogVersionRequest,
         abortSignal?: AbortSignal
-    ): Promise<MetadataApi.VersionResponse> {
+    ): Promise<number> {
         const builder = await this.getRequestBuilder(
             "metadata",
             HRN.fromString(this.hrn),
@@ -106,7 +106,7 @@ export class CatalogClient {
             Promise.reject(`Error getting earliest catalog version: ${err}`)
         );
 
-        return Promise.resolve(earliestVersion);
+        return Promise.resolve(earliestVersion.version);
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
@@ -227,7 +227,7 @@ describe("CatalogClient", () => {
         );
 
         assert.isDefined(response);
-        expect(response).to.be.equal(mockedEarliestVersion);
+        expect(response).to.be.equal(mockedEarliestVersion.version);
     });
 
     it("Should method getEarliestVersion return error getting earliest catalog version", async () => {


### PR DESCRIPTION
Return data type changed to be the same as getLatestVersion method.

Signed-off-by: Vishal Deshmukh <vishal.deshmukh@here.com>