### PR TITLE
Improve return data type for getEarliestVersion method.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
@@ -93,7 +93,7 @@ export class CatalogClient {
     public async getEarliestVersion(
         request: CatalogVersionRequest,
         abortSignal?: AbortSignal
-    ): Promise<MetadataApi.VersionResponse> {
+    ): Promise<number> {
         const builder = await this.getRequestBuilder(
             "metadata",
             HRN.fromString(this.hrn),
@@ -106,7 +106,7 @@ export class CatalogClient {
             Promise.reject(`Error getting earliest catalog version: ${err}`)
         );
 
-        return Promise.resolve(earliestVersion);
+        return Promise.resolve(earliestVersion.version);
     }
 
     /**
@@ -145,9 +145,11 @@ export class CatalogClient {
                 latestVersionError = error;
                 return undefined;
             });
-            
+
             if (!requestedCatalogVersion) {
-                return Promise.reject(`Failed to get the latest version with error: ${latestVersionError}`);
+                return Promise.reject(
+                    `Failed to get the latest version with error: ${latestVersionError}`
+                );
             }
         }
 
@@ -160,7 +162,9 @@ export class CatalogClient {
             return undefined;
         });
         if (!layerVersions) {
-            return Promise.reject(`Failed to get layerVersions with error: ${layerVersionsError}`);
+            return Promise.reject(
+                `Failed to get layerVersions with error: ${layerVersionsError}`
+            );
         }
 
         return Promise.resolve(layerVersions.layerVersions);
@@ -195,7 +199,7 @@ export class CatalogClient {
             startVersion,
             billingTag: request.getBillingTag()
         });
-        return latestVersion.version;
+        return Promise.resolve(latestVersion.version);
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
@@ -29,7 +29,6 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-
 class MockCatalogVersionRequest {
     public getBillingTag(): string | undefined {
         return "testBillingTag";
@@ -227,7 +226,7 @@ describe("CatalogClient", () => {
         );
 
         assert.isDefined(response);
-        expect(response).to.be.equal(mockedEarliestVersion);
+        expect(response).to.be.equal(mockedEarliestVersion.version);
     });
 
     it("Should method getEarliestVersion return error getting earliest catalog version", async () => {


### PR DESCRIPTION
Return data type changed to be the same as getLatestVersion method.

Signed-off-by: Vishal Deshmukh <vishal.deshmukh@here.com>