### PR TITLE
Add additionalFields support for PartitionsRequest.

### DIFF
--- a/@here/olp-sdk-dataservice-api/index.ts
+++ b/@here/olp-sdk-dataservice-api/index.ts
@@ -29,6 +29,8 @@ import * as MetadataApi from "./lib/metadata-api";
 import * as QueryApi from "./lib/query-api";
 import * as VolatileBlobApi from "./lib/volatile-blob-api";
 
+export type AdditionalFields = Array<"dataSize" | "checksum" | "compressedDataSize" | "crc">;
+
 export {
     LookupApi,
     MetadataApi,

--- a/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
@@ -17,6 +17,7 @@
  * License-Filename: LICENSE
  */
 
+import { AdditionalFields } from "@here/olp-sdk-dataservice-api";
 import { validateBillingTag, validatePartitionsIdsList } from "..";
 
 /**
@@ -26,6 +27,7 @@ export class PartitionsRequest {
     private version?: number;
     private billingTag?: string;
     private partitionIds?: string[];
+    private additionalFields?: AdditionalFields;
 
     /**
      * Gets a layer version for the request.
@@ -92,5 +94,26 @@ export class PartitionsRequest {
      */
     public getPartitionIds(): string[] | undefined {
         return this.partitionIds;
+    }
+
+    /**
+     * A setter for the provided additional fields: dataSize, checksum, compressedDataSize, crc.
+     *
+     * @param additionalFields Array of strings. Array could contain next values "dataSize" | "checksum" | "compressedDataSize".
+     *
+     * @returns The updated [[PartitionsRequest]] instance that you can use to chain methods.
+     */
+    public withAdditionalFields(additionalFields: AdditionalFields): PartitionsRequest {
+        this.additionalFields = additionalFields;
+        return this;
+    }
+
+    /**
+     * Gets additional fields for the request.
+     *
+     * @return The `partitionIds` string.
+     */
+    public getAdditionalFields(): AdditionalFields | undefined {
+        return this.additionalFields;
     }
 }

--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -221,6 +221,7 @@ export class VersionedLayerClient {
         return MetadataApi.getPartitions(metaRequestBilder, {
             version,
             layerId: this.layerId,
+            additionalFields: request.getAdditionalFields(),
             billingTag: request.getBillingTag()
         });
     }

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -214,6 +214,7 @@ export class VolatileLayerClient {
         );
         return MetadataApi.getPartitions(metaRequestBilder, {
             layerId: this.layerId,
+            additionalFields: request.getAdditionalFields(),
             billingTag: request.getBillingTag()
         });
     }

--- a/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
@@ -32,6 +32,7 @@ describe("PartitionsRequest", () => {
     const billingTag = "billingTag";
     const mockedVersion = 42;
     const mockedIds = ["1", "2", "13", "42"];
+    const mockedAdditionalFields = ["dataSize","checksum","compressedDataSize","crc"];
 
     it("Should initialize", () => {
         const partitionsRequest = new PartitionsRequest();
@@ -45,20 +46,24 @@ describe("PartitionsRequest", () => {
         const partitionsRequestWithVersion = partitionsRequest.withVersion(mockedVersion);
         const partitionsRequestWithBillTag = partitionsRequest.withBillingTag(billingTag);
         const partitionsRequestWithIds = partitionsRequest.withPartitionIds(mockedIds);
+        const partitionsAdditionalFields = partitionsRequest.withAdditionalFields(["dataSize","checksum","compressedDataSize","crc"]);
 
         expect(partitionsRequestWithVersion.getVersion()).to.be.equal(mockedVersion);
         expect(partitionsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
         expect(partitionsRequestWithIds.getPartitionIds()).to.be.equal(mockedIds);
+        assert.isDefined(partitionsAdditionalFields.getAdditionalFields());
     });
 
     it("Should get parameters with chain", () => {
         const partitionsRequest = new PartitionsRequest()
             .withVersion(mockedVersion)
             .withBillingTag(billingTag)
-            .withPartitionIds(mockedIds);
+            .withPartitionIds(mockedIds)
+            .withAdditionalFields(["dataSize","checksum","compressedDataSize","crc"]);
 
         expect(partitionsRequest.getVersion()).to.be.equal(mockedVersion);
         expect(partitionsRequest.getBillingTag()).to.be.equal(billingTag);
         expect(partitionsRequest.getPartitionIds()).to.be.equal(mockedIds);
+        assert.isDefined(partitionsRequest.getAdditionalFields());
     });
 });


### PR DESCRIPTION
* Add additionalFields support for partitions metadata request.

* Add additionalFields support to PartitionsRequest class

* Update methods getPartitions in VersionedLayerClient and VolatileLayerClient to provide for consumers ability to request additionals fields in the partitions metadata like checksum, dataSize, compressedDataSize, crc.

* Add unit tests for PartitionsRequest class and methods getPartitions.

Relates-To: OLPEDGE-1343.

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>