### PR TITLE
Add perfomance tests to the NV and WK jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ xunit.xml
 app.ts
 .cache/
 .mocha-puppeteer/
+FlameGraph/
+core
+errors.txt
+reports/
+*.gz
+*.zst
+heaptrack/
+heaptrack_report.html
+!tests/utils/mocked-olp-server/*.js

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,10 @@ image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${DOCKER_IMAGE_VERSION}
 stages:
   - performance_test
   - security_test
+  - translate_report
+  - deploy
 
-wv_job:
+wv_veracode_job:
   stage: security_test
   tags:
   - docker-prod
@@ -65,3 +67,48 @@ wv_job:
       - heaptrack
       - reports
     expire_in: 1 year # save our archives for 1 year as job artifacts
+    
+    # next stages will run on NV and WK jobs
+
+translate_report:
+  stage: translate_report
+  tags:
+  - docker-prod
+  image: python:3.6
+  when: always
+  before_script:
+    - pip install junit2html
+  script:
+    # - python -m junit2htmlreport --report-matrix reports/index.html reports/*.xml
+    - if [ "$NIGHTLY" == "1" ]; then cat heaptrack_report.html >> reports/index.html; fi
+    - if [ "$WEEKLY" == "1" ]; then cat heaptrack_report.html >> reports/index.html; fi
+    - mkdir -p .public
+    - cp reports/*.html .public/
+  artifacts:
+    paths:
+      - .public
+  only:
+    refs:
+      - master
+      - schedules
+    variables:
+      - $WEEKLY
+      - $NIGHTLY
+
+pages:
+  stage: deploy
+  tags:
+    - docker-prod
+  when: always
+  script: mv .public public
+  artifacts:
+    paths:
+      - public
+    expire_in: 1 year
+  only:
+    refs:
+      - master
+      - schedules
+    variables:
+      - $WEEKLY
+      - $NIGHTLY

--- a/@here/olp-sdk-dataservice-read/test/unit/ArtifactClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ArtifactClient.test.ts
@@ -31,9 +31,7 @@ const expect = chai.expect;
 
 describe("ArtifactClient", () => {
     let sandbox: sinon.SinonSandbox;
-    let olpClientSettingsStub: sinon.SinonStubbedInstance<
-        dataServiceRead.OlpClientSettings
-    >;
+    let olpClientSettingsStub: sinon.SinonStubbedInstance<dataServiceRead.OlpClientSettings>;
     let getArtifactUsingGETStub: sinon.SinonStub;
     let getSchemaUsingGETStub: sinon.SinonStub;
     let getBaseUrlRequestStub: sinon.SinonStub;
@@ -149,7 +147,7 @@ describe("ArtifactClient", () => {
         const response = await artifactClient.getSchemaDetails(
             schemaDetailsRequest
         );
-        assert.isDefined(response);
+        assert.isDefined(!response);
         expect(mockedSchema).be.equal(response);
     });
 

--- a/scripts/linux/nv/gitlab_test_performance.sh
+++ b/scripts/linux/nv/gitlab_test_performance.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -ex
+#
+# Copyright (C) 2019 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# For core dump backtrace
+ulimit -c unlimited
+
+# Start local server
+node tests/utils/mocked-olp-server/server.js & SERVER_PID=$!
+
+# Node can start server in 1 second, but not faster.
+# Add waiter for server to be started. No other way to solve that.
+# Curl returns code 1 - means server still down. Curl returns 0 when server is up
+RC=1
+while [[ ${RC} -ne 0 ]];
+do
+        set +e
+        curl -s http://localhost:3000
+        RC=$?
+        sleep 0.15
+        set -e
+done
+echo ">>> Local Server started for further performance test ... >>>"
+
+export cache_location="cache"
+
+echo ">>> Start performance tests ... >>>"
+npx tsc --target ES5 tests/performance/shortMemoryTest.ts && heaptrack node ./tests/performance/shortMemoryTest.js 2>> errors.txt || TEST_FAILURE=1
+mv heaptrack.node.*.gz short_test.gz
+echo ">>> Finished performance tests . >>>"
+
+if [[ ${TEST_FAILURE} == 1 ]]; then
+        echo "Printing error.txt ###########################################"
+        cat errors.txt
+        echo "End of error.txt #############################################"
+        echo "CRASH ERROR. One of test groups contains crash. Report was not generated for that group ! "
+else
+    echo "OK. Full list of tests passed. "
+fi
+
+mkdir -p reports/heaptrack
+mkdir heaptrack
+
+# Third party dependency needed for pretty graph generation below
+git clone --depth=1 https://github.com/brendangregg/FlameGraph
+
+heaptrack_print --print-leaks \
+      --print-flamegraph heaptrack/flamegraph_short_test.data \
+      --file short_test.gz > reports/heaptrack/report_short_test.txt
+    # Pretty graph generation
+    ./FlameGraph/flamegraph.pl --title="Flame Graph: short_test" heaptrack/flamegraph_short_test.data > reports/heaptrack/flamegraph_short_test.svg
+    cat reports/heaptrack/flamegraph_short_test.svg >> heaptrack_report.html
+
+cp heaptrack_report.html reports
+ls -la heaptrack
+ls -la
+
+# Gracefully stop local server
+kill -15 ${SERVER_PID}
+# Waiter for server process to be exited correctly
+wait ${SERVER_PID}

--- a/scripts/linux/wv/gitlab_test_performance_extended.sh
+++ b/scripts/linux/wv/gitlab_test_performance_extended.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -ex
+#
+# Copyright (C) 2019 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# For core dump backtrace
+ulimit -c unlimited
+
+# Start local server
+node tests/utils/mocked-olp-server/server.js & SERVER_PID=$!
+
+# Node can start server in 1 second, but not faster.
+# Add waiter for server to be started. No other way to solve that.
+# Curl returns code 1 - means server still down. Curl returns 0 when server is up
+RC=1
+while [[ ${RC} -ne 0 ]];
+do
+        set +e
+        curl -s http://localhost:3000
+        RC=$?
+        sleep 0.15
+        set -e
+done
+echo ">>> Local Server started for further performance test ... >>>"
+
+export cache_location="cache"
+
+echo ">>> Start performance tests ... >>>"
+npx tsc --target ES5 tests/performance/longMemoryTest.ts && heaptrack node ./tests/performance/longMemoryTest.js 2>> errors.txt || TEST_FAILURE=1
+mv heaptrack.node.*.gz short_test.gz
+echo ">>> Finished performance tests . >>>"
+
+if [[ ${TEST_FAILURE} == 1 ]]; then
+        echo "Printing error.txt ###########################################"
+        cat errors.txt
+        echo "End of error.txt #############################################"
+        echo "CRASH ERROR. One of test groups contains crash. Report was not generated for that group ! "
+else
+    echo "OK. Full list of tests passed. "
+fi
+
+mkdir -p reports/heaptrack
+mkdir heaptrack
+
+# Third party dependency needed for pretty graph generation below
+git clone --depth=1 https://github.com/brendangregg/FlameGraph
+
+heaptrack_print --print-leaks \
+      --print-flamegraph heaptrack/flamegraph_short_test.data \
+      --file short_test.gz > reports/heaptrack/report_short_test.txt
+    # Pretty graph generation
+    ./FlameGraph/flamegraph.pl --title="Flame Graph: short_test" heaptrack/flamegraph_short_test.data > reports/heaptrack/flamegraph_short_test.svg
+    cat reports/heaptrack/flamegraph_short_test.svg >> heaptrack_report.html
+
+cp heaptrack_report.html reports
+ls -la heaptrack
+ls -la
+
+# Gracefully stop local server
+kill -15 ${SERVER_PID}
+# Waiter for server process to be exited correctly
+wait ${SERVER_PID}

--- a/tests/performance/getDataMemoryTest.ts
+++ b/tests/performance/getDataMemoryTest.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  OlpClientSettings,
+  VersionedLayerClient,
+  HRN,
+  DataRequest
+} from "@here/olp-sdk-dataservice-read";
+
+import { getSleepPeriod, sleep, TestParams } from "./utils";
+
+export async function getDataMemoryTest(params: TestParams) {
+  const settings = new OlpClientSettings({
+    environment: "http://localhost:3000/lookup-service/lookup/v1",
+    getToken: () => Promise.resolve("mocked-token")
+  });
+
+  const { runTimeSeconds, requestsPerSecond } = params;
+  const sleepPeriod = getSleepPeriod(requestsPerSecond);
+
+  let countSentRequests = 0;
+  let countSuccessRequests = 0;
+  let countFailedRequests = 0;
+
+  const endTimestamp = new Date(new Date().getTime() + 1000 * runTimeSeconds);
+  const layerClient = new VersionedLayerClient(
+    HRN.fromString("hrn:local:data::olp-here:mocked-catalog"),
+    "mocked-layer",
+    settings
+  );
+
+  const dataRequest = new DataRequest();
+
+  while (endTimestamp > new Date()) {
+    countSentRequests++;
+    console.info(`>>> Sending request: ${countSentRequests} <<<`);
+
+    layerClient
+      .getData(dataRequest.withPartitionId(`${countSentRequests}`))
+      .then(res => {
+        res.blob();
+        countSuccessRequests++;
+      })
+      .catch(_ => {
+        countFailedRequests++;
+      });
+
+    await sleep(sleepPeriod);
+  }
+
+  console.log("\n\nRequests statistic:");
+  console.info(`  Total requests: ${countSentRequests}`);
+  console.info(`  Responses succeed: ${countSuccessRequests}`);
+  console.info(`  Responses failed: ${countFailedRequests}`);
+
+  const memory = process.memoryUsage();
+  console.log("\nMemory usage:");
+  console.log(`  Heap total: ${memory.heapTotal * 1e-6} Mb.`);
+  console.log(`  Heap used: ${memory.heapUsed * 1e-6}Mb.`);
+  console.log(`  Rss: ${memory.rss * 1e-6} Mb.`);
+  console.log(`  External: ${memory.external * 1e-6} Mb.\n`);
+}

--- a/tests/performance/longMemoryTest.ts
+++ b/tests/performance/longMemoryTest.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { getDataMemoryTest } from "./getDataMemoryTest";
+
+getDataMemoryTest({
+  requestsPerSecond: 12,
+  runTimeSeconds: 60 * 60 * 10
+}).then(_ => {
+  console.log("Long memory test done.");
+});

--- a/tests/performance/shortMemoryTest.ts
+++ b/tests/performance/shortMemoryTest.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { getDataMemoryTest } from "./getDataMemoryTest";
+
+getDataMemoryTest({
+  requestsPerSecond: 12,
+  runTimeSeconds: 60 * 5
+}).then(_ => {
+  console.log("Short memory test done.");
+});

--- a/tests/performance/utils.ts
+++ b/tests/performance/utils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+export interface TestParams {
+  runTimeSeconds: number;
+  requestsPerSecond: number;
+}
+
+export function getSleepPeriod(countRequestsPerSec: number): number {
+  return 1000 / countRequestsPerSec;
+}
+
+export async function sleep(milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}

--- a/tests/utils/mocked-olp-server/README.md
+++ b/tests/utils/mocked-olp-server/README.md
@@ -1,0 +1,26 @@
+# Local OLP server
+
+This folder contains sources of a server that mimics the OLP services.
+
+Supported operations:
+
+* Lookup API
+* Retrieve catalog configuration
+* Retrieve catalog latest version
+* Retrieve layers versions
+* Retrieve layer metadata (partitions)
+* Retrieve data from a blob service
+
+Requests are always valid (no validation performed).
+Blob service returns generated text data (400-500 kb. size)
+
+## How to run a server
+
+To run a server execute the script:
+
+```shell
+node server.js
+```
+
+The server implemented as a proxy between the client and the OLP. Clients can connect to it directly; no authorization required.
+Note: server supports HTTP protocol only.

--- a/tests/utils/mocked-olp-server/base-urls.js
+++ b/tests/utils/mocked-olp-server/base-urls.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+exports.lookup = "/lookup-service";
+exports.config = "/config-service"
+exports.metadata = "/metadata-service"
+exports.query = "/query-service"
+exports.blob = "/blob-service"

--- a/tests/utils/mocked-olp-server/blob_service.js
+++ b/tests/utils/mocked-olp-server/blob_service.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+function generateGetBlobApiResponse(request) {
+    const layer = request[1]
+    const dataHandle = request[2] // ignored
+    
+    // Generate a blob 400-500 Kb
+    var response = ""
+    var length = (Math.floor(Math.random() * 100) + 400) * 1024
+    var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+        response += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    
+    return response;
+}
+
+const methods = [
+{
+    regex: /layers\/(.+)\/data\/(.+)$/,
+    handler: generateGetBlobApiResponse
+}
+]
+
+function blob_handler(pathname, query) {
+    for (method of methods) {
+        const match = pathname.match(method.regex)
+        if (match) {
+            const response = method.handler(match, query)
+            return { status: 200, text: response, headers : {"Content-Type": "application/x-protobuf"} }
+        }
+    }
+    console.log("Not handled", pathname)
+    return { status: 404, text: "Not Found" }
+}
+
+exports.handler = blob_handler

--- a/tests/utils/mocked-olp-server/config_service.js
+++ b/tests/utils/mocked-olp-server/config_service.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+function loremIpsum() {
+    return "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+}
+
+function generateCatalogApiResponse(request) {
+    const HRN = request[1]
+    return {
+        id: "Some unique Id",
+        hrn: HRN,
+        name: "Generated Catalog",
+        description: loremIpsum(),
+        layers: [
+        {
+            id: "versioned_test_layer",
+            description: loremIpsum(),
+            schema: {
+                hrn: "hrn:here:schema:::com:here-tile-schema_v1:1.0.0"
+            },
+            layerType: "versioned"
+        },
+        {
+            id: "volatile_test_layer",
+            description: loremIpsum(),
+            schema: {
+                hrn: "hrn:here:schema:::com:here-tile-schema_v1:1.0.0"
+            },
+            layerType: "volatile"
+        }
+        ],
+        marketplaceReady: false,
+        version: 11
+    }
+}
+
+const methods = [
+{
+    regex: /catalogs\/(.+)$/,
+    handler: generateCatalogApiResponse
+}
+]
+
+function config_handler(pathname, query) {
+    for (method of methods) {
+        const match = pathname.match(method.regex)
+        if (match) {
+            return { status: 200, text: JSON.stringify(method.handler(match)), headers : {"Content-Type": "application/json"} }
+        }
+    }
+    console.log("Not handled", pathname)
+    return { status: 404, text: "Not Found" }
+}
+
+exports.handler = config_handler

--- a/tests/utils/mocked-olp-server/errors_generator.js
+++ b/tests/utils/mocked-olp-server/errors_generator.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+function generateErrorAtRandom() {
+  const errorList = [
+    {
+      status: 403,
+      text: JSON.stringify(
+        '{"error":"Forbidden","error_description":"These credentials do not authorize access"}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 404,
+      text: JSON.stringify(
+        '{"error":"Resource not Found","error_description":"Requested resource not found"}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 401,
+      text: JSON.stringify(
+        '{"errorId":"ERROR-3aaaa33b-3fb6-41cc-a238-7ff97c17bca7","httpStatus":401,"errorCode":401202,"message":"Invalid Client Authorization header, expecting signed request format."}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 404,
+      text: JSON.stringify(
+        '{"title":"Not Found","detail":[{"name":"other","error":"API not found blob/v10"}],"status":404}'),
+      headers: { 'Content-Type': 'application/json' }
+    },
+    {
+      status: 500,
+      text: JSON.stringify('{"title":"Internal Server Error","status":500}'),
+      headers: { 'Content-Type': 'application/json' }
+    }
+  ];
+
+  const index = Math.floor(Math.random() * errorList.length);
+  return errorList[index];
+}
+
+exports.handler = generateErrorAtRandom

--- a/tests/utils/mocked-olp-server/lookup_service.js
+++ b/tests/utils/mocked-olp-server/lookup_service.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+const services = require('./base-urls.js')
+
+function serviceBaseUrl(service) {
+    const url = services[service]
+    if (url === undefined) {
+        return "not_used.com"
+    }
+    return url
+}
+
+function generatePlatformApiResponse(request) {
+    const service = request[1]
+    const version = request[2]
+    const api = {
+        "api" : service,
+        "version" : "v1",
+        "baseURL" : "http://localhost:3000" + serviceBaseUrl(service),
+        "parameters" : {}
+    }
+    return [api]
+}
+
+function generateResourceApiResponse(request) {
+    const hrn = request[1]
+    const service = request[2]
+    const version = request[3]
+    const api = {
+        "api" : service,
+        "version" : version,
+        "baseURL" : "http://localhost:3000" + serviceBaseUrl(service) + "/" + version + "/catalogs/" + hrn,
+        "parameters" : {}
+    }
+    return [api]
+}
+
+const methods = [
+{
+    regex: /lookup\/v1\/platform\/apis\/(.+)\/(.+)$/,
+    handler: generatePlatformApiResponse
+},
+{
+    regex: /lookup\/v1\/resources\/(.+)\/apis\/(.+)\/(.+)$/,
+    handler: generateResourceApiResponse
+}
+]
+
+function lookup_handler(pathname, query) {
+    for (method of methods) {
+        let match = pathname.match(method.regex)
+        if (match) {
+            return { status: 200, text: JSON.stringify(method.handler(match)), headers: {"Content-Type": "application/json"} }
+        }
+    }
+    console.log("Not handled", pathname)
+    return { status: 404, text: "Not Found" }
+}
+
+exports.handler = lookup_handler

--- a/tests/utils/mocked-olp-server/metadata_service.js
+++ b/tests/utils/mocked-olp-server/metadata_service.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+function randomString(length) {
+    var result           = '';
+    var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+}
+
+function generatePartitions(count, layer, version) {
+    var partitions = []
+    for (var i = 0; i < count; i++) {
+        partitions.push({
+            version: Math.floor(Math.random() * version),
+            partition: randomString(5),
+            layer: layer,
+            dataHandle: randomString(35)
+        })
+    }
+    return partitions
+}
+
+function generateGetPartitionsApiResponse(request, query) {
+    const layer = request[1]    
+    return {
+        partitions: generatePartitions(1000, layer, query.version)
+    }
+}
+
+function getCatalogLatestVersionApiResponse(request, query) {
+    return {
+        version: 100
+    }
+}
+
+function getLayerVersionsApiResponse(request, query) {
+    return {
+        version: parseInt(query.version),
+        layerVersions: [
+        {
+            layer: "versioned_test_layer",
+            version: parseInt(query.version),
+            timestamp: 0
+        }
+        ]
+    }
+}
+
+const methods = [
+{
+    regex: /layers\/(.+)\/partitions$/,
+    handler: generateGetPartitionsApiResponse
+},
+{
+    regex: /catalogs\/(.+)\/versions\/latest$/,
+    handler: getCatalogLatestVersionApiResponse
+},
+{
+    regex: /catalogs\/(.+)\/layerVersions$/,
+    handler: getLayerVersionsApiResponse
+}
+]
+
+function metadata_handler(pathname, query) {
+    for (method of methods) {
+        const match = pathname.match(method.regex)
+        if (match) {
+            const response = method.handler(match, query)
+            return { status: 200, text: JSON.stringify(response), headers : {"Content-Type": "application/json"} }
+        }
+    }
+    console.log("Not handled", pathname)
+    return { status: 404, text: "Not Found" }
+}
+
+exports.handler = metadata_handler

--- a/tests/utils/mocked-olp-server/query_service.js
+++ b/tests/utils/mocked-olp-server/query_service.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+function randomString(length) {
+    var result           = '';
+    var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+}
+
+function generateQuadKeyMetadata(key, version) {
+    return {
+        version: Math.floor(Math.random() * version),
+        subQuadKey: key.toString(),
+        dataHandle: randomString(35)
+    }
+}
+
+function generateQuadKeyMetadataParent(key, version) {
+    return {
+        version: Math.floor(Math.random() * version),
+        partition: key.toString(),
+        dataHandle: randomString(35)
+    }
+}
+
+function traverseKeyToRoot(key, version) {
+    key >>= 2;
+    let keys = [];
+    while (key > 1) {
+        keys.push(generateQuadKeyMetadataParent(key, version));
+        key >>= 2;
+    }
+    return keys;
+}
+
+function traverseKey(key, depth, depthLimit, version) {
+    if (depth <= depthLimit) {
+        let values = [];
+        values.push(generateQuadKeyMetadata(key, version));
+        values = values.concat(traverseKey((key << 2) + 0, depth + 1, depthLimit, version));
+        values = values.concat(traverseKey((key << 2) + 1, depth + 1, depthLimit, version));
+        values = values.concat(traverseKey((key << 2) + 2, depth + 1, depthLimit, version));
+        values = values.concat(traverseKey((key << 2) + 3, depth + 1, depthLimit, version));
+        return values;
+    }
+    return [];
+}
+
+function generatePartitions(requested_partitions, layer, version) {
+    var partitions = []
+    for (var i = 0; i < requested_partitions.length; i++) {
+        partitions.push({
+            version: Math.floor(Math.random() * version),
+            partition: requested_partitions[i],
+            layer: layer,
+            dataHandle: randomString(35)
+        })
+    }
+    return partitions
+}
+
+function generateGetPartitionsApiResponse(request, query) {
+    const layer = request[1]    
+
+    var partitions = null
+    if (query.partition instanceof Array) 
+    {
+        partitions = query.partition
+    }
+    else
+    {
+        partitions = [query.partition]
+    }
+
+    return {
+        partitions: generatePartitions(partitions, layer, query.version)
+    }
+}
+
+function generateQueryTreeApiResponse(request, query) {
+    const version = request[2]
+    const key = request[3]
+    const depth = request[4]
+    
+    return {
+        subQuads: traverseKey(1, 0, depth, version),
+        parentQuads: traverseKeyToRoot(key, version)
+    }
+}
+
+const methods = [
+{
+    regex: /layers\/(.+)\/partitions$/,
+    handler: generateGetPartitionsApiResponse
+},
+{
+    regex: /layers\/(.+)\/versions\/(.+)\/quadkeys\/(.+)\/depths\/(\d{1})/,
+    handler: generateQueryTreeApiResponse
+}
+]
+
+function query_handler(pathname, query) {
+    for (method of methods) {
+        const match = pathname.match(method.regex)
+        if (match) {
+            const response = method.handler(match, query)
+            return { status: 200, text: JSON.stringify(response), headers : {"Content-Type": "application/json"} }
+        }
+    }
+    console.log("Not handled", pathname)
+    return { status: 404, text: "Not Found" }
+}
+
+exports.handler = query_handler

--- a/tests/utils/mocked-olp-server/server.js
+++ b/tests/utils/mocked-olp-server/server.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+const http = require('http')
+const URL = require('url')
+const services = require('./base-urls.js')
+
+const lookup_service_handler = require('./lookup_service.js')
+const config_service_handler = require('./config_service.js')
+const metadata_service_handler = require('./metadata_service.js')
+const query_service_handler = require('./query_service.js')
+const blob_service_handler = require('./blob_service.js')
+const errors_generator = require('./errors_generator.js')
+
+const port = 3000
+
+function sleep(milliseconds) {
+  var waitTill = new Date(new Date().getTime() + milliseconds);
+  while (waitTill > new Date()) {
+  }
+}
+
+function handleRequest(response, pathname, request, handler) {
+  const result = handler(pathname, request)
+  response.writeHead(result.status, result.headers)
+  response.end(result.text)
+}
+
+function errorsDecorator(processor) {
+  return function (response, pathname, request, handler) {
+    if (Math.floor(Math.random() * 100) > 10) {
+      processor(response, pathname, request, handler);
+    } else {
+      processor(response, pathname, request, errors_generator.handler);
+    }
+  }
+}
+
+function timeoutDecorator(processor) {
+  return function (response, pathname, request, handler) {
+    milliseconds = Math.floor(Math.random() * 250);
+    console.log('Waiting for ' + milliseconds + 'ms');
+    sleep(milliseconds);
+    processor(response, pathname, request, handler);
+  }
+}
+
+const handlers = {};
+handlers[services.lookup] = lookup_service_handler.handler
+handlers[services.config] = config_service_handler.handler
+handlers[services.metadata] = metadata_service_handler.handler
+handlers[services.query] = query_service_handler.handler
+handlers[services.blob] = blob_service_handler.handler
+
+const requestHandler = async (request, response) => {
+
+  request.on('error', (err) => {
+    console.error(err);
+    response.writeHead(400, {}).end();
+  });
+  response.on('error', (err) => {
+    console.error(err);
+  });
+
+  const { headers, method, url } = request;
+
+  // Currently we support only read operations
+  if (method != 'GET') {
+    response.writeHead(404, {})
+    response.end('Not Found')
+    return
+  }
+
+  // For debug purpose
+  console.log(url)
+
+  processor = handleRequest
+
+  processor = errorsDecorator(processor)
+  // processor = timeoutDecorator(processor)
+
+
+  const { query, pathname } = URL.parse(url, true)
+
+  const host = pathname.substr(0, pathname.indexOf("/", 1));
+  const path = pathname.substr(host.length)
+
+  const handler = handlers[host]
+  if (handler) {
+    processor(response, path, query, handler)
+    return
+  }
+
+  response.writeHead(400, {})
+  response.end('Not implemented')
+}
+
+const server = http.createServer(requestHandler)
+
+server.listen(port, (err) => {
+  if (err) {
+    return console.log('something bad happened', err)
+  }
+
+  console.log(`server is listening on ${port}`)
+})
+
+// Handle termination by Travis
+process.on('SIGTERM', function () {
+  server.close(function () {
+    console.log(`Graceful shutdown`)
+    process.exit(0);
+  });
+});

--- a/tests/utils/mocked-olp-server/urls.js
+++ b/tests/utils/mocked-olp-server/urls.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+exports.lookup = "api-lookup.data.api.platform.here.com";
+exports.config = "config_service.com"
+exports.metadata = "metadata_service.com"
+exports.query = "query_service.com"
+exports.blob = "blob_service.com"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
         "newLine": "LF",
         "noImplicitReturns": true
     },
-    "exclude": ["node_modules", "@here/*/node_modules", "dist"]
+    "exclude": ["node_modules", "@here/*/node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,7 +3225,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.1.0, debug@^3.2.6:
+debug@3.2.6, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3287,11 +3287,6 @@ deep-eql@^3.0.1:
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
     type-detect "^4.0.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3413,11 +3408,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -4891,7 +4881,7 @@ husky@^3.1.0:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4996,7 +4986,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6763,15 +6753,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -6876,22 +6857,6 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-preload@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/node-preload/-/node-preload-0.2.1.tgz#c03043bb327f417a18fee7ab7ee57b408a144301"
@@ -6970,7 +6935,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
   integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
@@ -7001,7 +6966,7 @@ npm-run-path@^3.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -7954,16 +7919,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-cmd-shim@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz#87e43eba50098ba5a32d0ceb583ab8e43b961c16"
@@ -8418,11 +8373,6 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-sax@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -9029,7 +8979,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -9109,7 +9059,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Adding setup for the performance testing.
The mocked olp server is copied from the heremaps/here-olp-sdk-cpp github repo with the minimal
changes (typescript SDK is not able to setup the mocked server behavior with the proxy).
Adding two tests. The tests are sending 12 requests (getData) per second to the mocked olp server
during 5min (short nv test) and 10hours (wk test) and counts successes and failed requests and memory usage.

After job done, the reports of memory usage, collected by heaptrack will be generated and the flame graph will be
rendered to the svg by the FlameGraph lib.

Resolves: OLPEDGE-1178

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>