### PR TITLE
Add HttpError Class.

### DIFF
--- a/@here/olp-sdk-dataservice-api/index.ts
+++ b/@here/olp-sdk-dataservice-api/index.ts
@@ -18,6 +18,7 @@
  */
 
 export * from "./lib/RequestBuilder";
+export * from "./lib/HttpError";
 
 import * as ArtifactApi from "./lib/artifact-api";
 import * as BlobApi from "./lib/blob-api";
@@ -29,7 +30,9 @@ import * as MetadataApi from "./lib/metadata-api";
 import * as QueryApi from "./lib/query-api";
 import * as VolatileBlobApi from "./lib/volatile-blob-api";
 
-export type AdditionalFields = Array<"dataSize" | "checksum" | "compressedDataSize" | "crc">;
+export type AdditionalFields = Array<
+    "dataSize" | "checksum" | "compressedDataSize" | "crc"
+>;
 
 export {
     LookupApi,

--- a/@here/olp-sdk-dataservice-api/lib/HttpError.ts
+++ b/@here/olp-sdk-dataservice-api/lib/HttpError.ts
@@ -1,0 +1,22 @@
+/**
+ * HttpError class used to be able to provide for consumers
+ * a more usable errors from services. Would be used in the methods
+ * to propagate error with http status code and with a message in
+ * case if something went wrong during the request.
+ * The HttpError class extends generic Error class from V8 and
+ * adds property code for http status.
+ */
+export class HttpError extends Error {
+    public readonly name: string;
+
+    /**
+     * Constructs a new HttpError.
+     *
+     * @param status
+     * @param message
+     */
+    constructor(public status: number, public message: string) {
+        super(message);
+        this.name = "HttpError";
+    }
+}

--- a/@here/olp-sdk-dataservice-api/test/HttpError.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/HttpError.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import { HttpError } from "../index";
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("HttpErrorTest", () => {
+    const NOT_FOUND_ERROR_CODE = 404;
+    const error = new HttpError(NOT_FOUND_ERROR_CODE, "Not found");
+
+    it("HttpError shoud be initialized", async () => {
+        assert.isDefined(error);
+        expect(error).to.be.instanceOf(Error);
+        expect(error).to.be.instanceOf(HttpError);
+    });
+
+    it("HttpError should have parameters status, message and name", async () => {
+        expect(error.status).to.be.equal(NOT_FOUND_ERROR_CODE);
+        expect(error.message).to.be.equal("Not found");
+        expect(error.name).to.be.equal("HttpError");
+    });
+});


### PR DESCRIPTION
Add HttpError class.

Adding HttpError class to be able to provide for consumers
a more usable errors from services.
Would be used in the methods to propagate error with http status code
and with a message in case if something went wrong during the request.

The HttpError class extends generic Error class from V8 and
adds property code for http status.

Adding the unit tests and setup running unit tests for the dataservice-api component.

Resolves: OLPEDGE-1433

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>