### PR TITLE
Propagate HttpError class for getData methods

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
@@ -112,7 +112,7 @@ export class IndexLayerClient {
         return BlobApi.getBlob(builder, {
             dataHandle: model.id,
             layerId: this.layerId
-        }).catch(async error => Promise.reject(error));
+        });
     }
 
     /**
@@ -132,10 +132,6 @@ export class IndexLayerClient {
             this.settings,
             hrn,
             abortSignal
-        ).catch(err =>
-            Promise.reject(
-                `Error retrieving from cache builder for resource "${this.catalogHrn}" and api: "${builderType}.\n${err}"`
-            )
-        );
+        ).catch(err => Promise.reject(err));
     }
 }

--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -246,9 +246,12 @@ export class VersionedLayerClient {
         const queryRequestBilder = await this.getRequestBuilder(
             "query",
             HRN.fromString(this.hrn)
-        );
+        ).catch(error => Promise.reject(error));
         const latestVersion =
-            version || (await this.getLatestVersion(billingTag));
+            version ||
+            (await this.getLatestVersion(billingTag).catch(error =>
+                Promise.reject(error)
+            ));
         const partitionsListRepsonse = await QueryApi.getPartitionsById(
             queryRequestBilder,
             {
@@ -257,7 +260,7 @@ export class VersionedLayerClient {
                 partition: [partitionId],
                 billingTag
             }
-        ).catch(async error => Promise.reject(error));
+        ).catch(error => Promise.reject(error));
 
         if (
             partitionsListRepsonse.status &&
@@ -290,15 +293,7 @@ export class VersionedLayerClient {
         const latestVersion = await MetadataApi.latestVersion(builder, {
             startVersion: -1,
             billingTag
-        }).catch(async (error: Response) =>
-            Promise.reject(
-                new Error(
-                    `Metadata Service error: HTTP ${
-                        error.status
-                    }, ${error.statusText || ""}`
-                )
-            )
-        );
+        }).catch(error => Promise.reject(error));
         return latestVersion.version;
     }
 
@@ -311,12 +306,12 @@ export class VersionedLayerClient {
             "blob",
             HRN.fromString(this.hrn),
             abortSignal
-        );
+        ).catch(error => Promise.reject(error));
         return BlobApi.getBlob(builder, {
             dataHandle,
             layerId: this.layerId,
             billingTag
-        }).catch(async error => Promise.reject(error));
+        }).catch(error => Promise.reject(error));
     }
 
     /**
@@ -336,10 +331,6 @@ export class VersionedLayerClient {
             this.settings,
             hrn,
             abortSignal
-        ).catch(err =>
-            Promise.reject(
-                `Error retrieving from cache builder for resource "${this.hrn}" and api: "${builderType}.\n${err}"`
-            )
-        );
+        ).catch(error => Promise.reject(error));
     }
 }

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -99,7 +99,7 @@ export class VolatileLayerClient {
                     partitionId,
                     dataRequest.getBillingTag(),
                     abortSignal
-                ).catch((error: Response) => Promise.reject(error));
+                ).catch(error => Promise.reject(error));
                 return this.downloadPartition(
                     partitionIdDataHandle,
                     abortSignal,
@@ -214,7 +214,7 @@ export class VolatileLayerClient {
         const metaRequestBilder = await this.getRequestBuilder(
             "metadata",
             HRN.fromString(this.hrn)
-        );
+        ).catch(error => Promise.reject(error));
         return MetadataApi.getPartitions(metaRequestBilder, {
             layerId: this.layerId,
             additionalFields: request.getAdditionalFields(),
@@ -231,12 +231,12 @@ export class VolatileLayerClient {
             "volatile-blob",
             HRN.fromString(this.hrn),
             abortSignal
-        );
+        ).catch(error => Promise.reject(error));
         return VolatileBlobApi.getVolatileBlob(builder, {
             dataHandle,
             layerId: this.layerId,
             billingTag
-        }).catch(async error => Promise.reject(error));
+        }).catch(error => Promise.reject(error));
     }
 
     /**
@@ -256,10 +256,6 @@ export class VolatileLayerClient {
             this.settings,
             hrn,
             abortSignal
-        ).catch(err =>
-            Promise.reject(
-                `Error retrieving from cache builder for resource "${this.hrn}" and api: "${builderType}.\n${err}"`
-            )
         );
     }
 
@@ -276,7 +272,7 @@ export class VolatileLayerClient {
         const queryRequestBilder = await this.getRequestBuilder(
             "query",
             HRN.fromString(this.hrn)
-        );
+        ).catch(error => Promise.reject(error));
         const partitionsListRepsonse = await QueryApi.getPartitionsById(
             queryRequestBilder,
             {
@@ -284,7 +280,7 @@ export class VolatileLayerClient {
                 partition: [partitionId],
                 billingTag
             }
-        );
+        ).catch(error => Promise.reject(error));
 
         if (
             partitionsListRepsonse.status &&

--- a/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
@@ -74,11 +74,7 @@ export class RequestFactory {
                           `Error getting base url to the service: ${serviceName}`
                       )
             )
-            .catch(error =>
-                Promise.reject(
-                    `Error building Request for service: ${serviceName}.\n${error}`
-                )
-            );
+            .catch(error => Promise.reject(error));
     }
 
     /**
@@ -159,8 +155,6 @@ export class RequestFactory {
                     );
                 }
             )
-            .catch((error: string) =>
-                Promise.reject(`Getting API ${serviceName} error: ${error}`)
-            );
+            .catch(error => Promise.reject(error));
     }
 }

--- a/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
@@ -106,6 +106,7 @@ describe("IndexLayerClient", () => {
                 }
             ]
         };
+
         getIndexStub.callsFake(
             (builder: any, params: any): Promise<IndexApi.DataResponse> => {
                 return Promise.resolve(mockedIndexResponse);
@@ -250,6 +251,33 @@ describe("IndexLayerClient", () => {
             .catch(error => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error);
+            });
+    });
+
+    it("Should base url error be handled", async () => {
+        const mockedModel = {
+            id: "8c0e5ac9-b036-4365-8820-dfcba64588fc",
+            size: 111928,
+            checksum: "448a33cd65c47bed1eeb4d72e7fa022c95a41158",
+            timestamp: 1551981674191,
+            hour_from: 1506402000000,
+            tile_id: 377894442,
+            crc: null
+        };
+        const mockedErrorResponse = "Bad response";
+
+        getBaseUrlRequestStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        const response = await indexLayerClient
+            .getData(mockedModel)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
             });
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
@@ -176,7 +176,7 @@ describe("RequestFactory", () => {
                 );
             } catch (error) {
                 expect(error).to.be.equal(
-                    "Error building Request for service: statistics.\nGetting API statistics error: Getting API statistics unknown error"
+                    "Getting API statistics unknown error"
                 );
             }
         });
@@ -249,9 +249,7 @@ describe("RequestFactory", () => {
                     settings as any
                 );
             } catch (error) {
-                expect(error).to.be.equal(
-                    "Getting API statistics error: Getting API error: Not Found"
-                );
+                expect(error).to.be.equal("Getting API error: Not Found");
             }
         });
 
@@ -274,7 +272,7 @@ describe("RequestFactory", () => {
                 );
             } catch (error) {
                 expect(error).to.be.equal(
-                    "Getting API statistics error: Getting API statistics unknown error"
+                    "Getting API statistics unknown error"
                 );
             }
         });

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -568,4 +568,25 @@ describe("VersionedLayerClient", () => {
             getQuadTreeIndexStub.getCalls()[0].args[1].additionalFields[2]
         ).to.be.equal("compressedDataSize");
     });
+
+    it("Should error be handled 2", async () => {
+        const mockedErrorResponse = "Bad response";
+        const dataRequest = new dataServiceRead.DataRequest().withDataHandle(
+            "moсked-data-handle"
+        );
+
+        getBaseUrlRequestStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        const response = await versionedLayerClient
+            .getData(dataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+    });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -598,4 +598,25 @@ describe("VolatileLayerClient", () => {
                 assert.equal(error, mockedPartitionsIdData);
             });
     });
+
+    it("Should error be handled 2", async () => {
+        const mockedErrorResponse = "Bad response";
+        const dataRequest = new dataServiceRead.DataRequest().withDataHandle(
+            "moсked-data-handle"
+        );
+
+        getBaseUrlRequestStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        const response = await volatileLayerClient
+            .getData(dataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+    });
 });


### PR DESCRIPTION
HttpError class provides to the consumers ability to error message and status from service.
Consolidating error handling strategy through all clients is a way to make it solid.

* Add HttpError usage to each API call from DataStoreDownloadManager
* Update DataStoreDownloadManager unit tests
* Update error handling approach for getData methods in VersionLayer, Volatile and IndexLayer clients
* Update unit tests for mentioned clients

Resolves: OLPEDGE-1434
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>