### PR TITLE
Propagate HttpError class for getPartitions methods

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -220,10 +220,12 @@ export class VersionedLayerClient {
             "metadata",
             HRN.fromString(this.hrn),
             abortSignal
-        );
+        ).catch(error => Promise.reject(error));
         const version =
             request.getVersion() ||
-            (await this.getLatestVersion(request.getBillingTag()));
+            (await this.getLatestVersion(request.getBillingTag()).catch(error =>
+                Promise.reject(error)
+            ));
         return MetadataApi.getPartitions(metaRequestBilder, {
             version,
             layerId: this.layerId,
@@ -311,7 +313,7 @@ export class VersionedLayerClient {
             dataHandle,
             layerId: this.layerId,
             billingTag
-        }).catch(error => Promise.reject(error));
+        });
     }
 
     /**
@@ -331,6 +333,6 @@ export class VersionedLayerClient {
             this.settings,
             hrn,
             abortSignal
-        ).catch(error => Promise.reject(error));
+        );
     }
 }

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -236,7 +236,7 @@ export class VolatileLayerClient {
             dataHandle,
             layerId: this.layerId,
             billingTag
-        }).catch(error => Promise.reject(error));
+        });
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -569,11 +569,15 @@ describe("VersionedLayerClient", () => {
         ).to.be.equal("compressedDataSize");
     });
 
-    it("Should error be handled 2", async () => {
+    it("Should baseUrl error be handled", async () => {
         const mockedErrorResponse = "Bad response";
-        const dataRequest = new dataServiceRead.DataRequest().withDataHandle(
+        const dataHandleRequest = new dataServiceRead.DataRequest().withDataHandle(
             "moсked-data-handle"
         );
+        const dataPartitionRequest = new dataServiceRead.DataRequest().withPartitionId(
+            "mocked-id"
+        );
+        const partitionsRrequest = new dataServiceRead.PartitionsRequest();
 
         getBaseUrlRequestStub.callsFake(() =>
             Promise.reject({
@@ -582,8 +586,93 @@ describe("VersionedLayerClient", () => {
             })
         );
 
-        const response = await versionedLayerClient
-            .getData(dataRequest)
+        const dataH = await versionedLayerClient
+            .getData(dataHandleRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+
+        const dataP = await versionedLayerClient
+            .getData(dataPartitionRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+
+        const partitions = await versionedLayerClient
+            .getPartitions(partitionsRrequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+    });
+
+    it("Should latestVersion error be handled", async () => {
+        const mockedErrorResponse = "Bad response";
+        const dataPartitionRequest = new dataServiceRead.DataRequest().withPartitionId(
+            "mocked-id"
+        );
+        const partitionsRrequest = new dataServiceRead.PartitionsRequest();
+
+        getVersionStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        const dataP = await versionedLayerClient
+            .getData(dataPartitionRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+
+        const partitions = await versionedLayerClient
+            .getPartitions(partitionsRrequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+
+        getBaseUrlRequestStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        const partitions1 = await versionedLayerClient
+            .getPartitions(partitionsRrequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+    });
+
+    it("Should getPartitions with quadKey error be handled", async () => {
+        const mockedErrorResponse = "Bad response";
+        const quadRrequest = new dataServiceRead.DataRequest()
+            .withQuadKey(dataServiceRead.quadKeyFromMortonCode("23618403"))
+            .withVersion(42);
+
+        getVersionStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        getQuadTreeIndexStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        const data = await versionedLayerClient
+            .getData(quadRrequest)
             .catch(error => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error.statusText);

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -599,11 +599,15 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    it("Should error be handled 2", async () => {
+    it("Should baseUrl error be handled", async () => {
         const mockedErrorResponse = "Bad response";
         const dataRequest = new dataServiceRead.DataRequest().withDataHandle(
             "moсked-data-handle"
         );
+        const dataPartitionRequest = new dataServiceRead.DataRequest().withPartitionId(
+            "mocked-id"
+        );
+        const partitionsRrequest = new dataServiceRead.PartitionsRequest();
 
         getBaseUrlRequestStub.callsFake(() =>
             Promise.reject({
@@ -612,8 +616,55 @@ describe("VolatileLayerClient", () => {
             })
         );
 
-        const response = await volatileLayerClient
+        const dataH = await volatileLayerClient
             .getData(dataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+
+        const dataP = await volatileLayerClient
+            .getData(dataPartitionRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+
+        const partitions = await volatileLayerClient
+            .getPartitions(partitionsRrequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.statusText);
+            });
+    });
+
+    it("Should getPartitions with quadKey error be handled", async () => {
+        const mockedErrorResponse = "Bad response";
+        const mockedVersion = {
+            version: 42
+        };
+        const quadRrequest = new dataServiceRead.DataRequest().withQuadKey(
+            dataServiceRead.quadKeyFromMortonCode("23618403")
+        );
+
+        getQuadTreeIndexStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        getVersionStub.callsFake(
+            (
+                builder: any,
+                params: any
+            ): Promise<MetadataApi.VersionResponse> => {
+                return Promise.resolve(mockedVersion);
+            }
+        );
+
+        const data = await volatileLayerClient
+            .getData(quadRrequest)
             .catch(error => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error.statusText);


### PR DESCRIPTION
HttpError class provides to the consumers ability to error message and status from service.
Consolidating error handling strategy through all clients is a way to make it solid.

* Update error handling approach for getPartitions methods in VersionLayerClient and VolatileLayerClient
* Update unit tests for mentioned clients

Resolves: OLPEDGE-1436
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>