### PR TITLE
Fix error messages in VersionLayerClient and VolatileLayerClient

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -17,7 +17,12 @@
  * License-Filename: LICENSE
  */
 
-import { BlobApi, MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
+import {
+    BlobApi,
+    HttpError,
+    MetadataApi,
+    QueryApi
+} from "@here/olp-sdk-dataservice-api";
 import {
     ApiName,
     DataRequest,
@@ -280,7 +285,10 @@ export class VersionedLayerClient {
         return partition && partition.dataHandle
             ? partition.dataHandle
             : Promise.reject(
-                  `No partition dataHandle for partition ${partitionId}. HRN: ${this.hrn}`
+                  new HttpError(
+                      404,
+                      `No partition dataHandle for partition ${partitionId}. HRN: ${this.hrn}`
+                  )
               );
     }
 

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -18,6 +18,7 @@
  */
 
 import {
+    HttpError,
     MetadataApi,
     QueryApi,
     VolatileBlobApi
@@ -27,7 +28,6 @@ import {
     DataRequest,
     DataStoreRequestBuilder,
     HRN,
-    mortonCodeFromQuadKey,
     OlpClientSettings,
     PartitionsRequest,
     QuadKeyPartitionsRequest,
@@ -298,7 +298,10 @@ export class VolatileLayerClient {
         return partition && partition.dataHandle
             ? partition.dataHandle
             : Promise.reject(
-                  `No partition dataHandle for partition ${partitionId}. HRN: ${this.hrn}`
+                  new HttpError(
+                      404,
+                      `No partition dataHandle for partition ${partitionId}. HRN: ${this.hrn}`
+                  )
               );
     }
 }

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -269,6 +269,43 @@ describe("VersionedLayerClient", () => {
             });
     });
 
+    it("Should method getData with wrong partitionId parameter and version return error", async () => {
+        const mockedBlobData = new Response("mocked-blob-response");
+        const mockedErrorResponse =
+            "No partition dataHandle for partition 42. HRN: hrn:here:data:::mocked-hrn";
+        const mockedPartitionsIdData = {
+            partitions: [
+                {
+                    version: 1,
+                    partition: "13",
+                    dataHandle: "3C3BE24A341D82321A9BA9075A7EF498.123"
+                }
+            ]
+        };
+
+        getPartitionsByIdStub.callsFake(
+            (builder: any, params: any): Promise<QueryApi.Partitions> => {
+                return Promise.resolve(mockedPartitionsIdData);
+            }
+        );
+        getBlobStub.callsFake(
+            (builder: any, params: any): Promise<Response> => {
+                return Promise.resolve(mockedBlobData);
+            }
+        );
+
+        const dataRequest = new dataServiceRead.DataRequest()
+            .withPartitionId("42")
+            .withVersion(2);
+
+        const response = await versionedLayerClient
+            .getData((dataRequest as unknown) as dataServiceRead.DataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.message);
+            });
+    });
+
     it("Should method getData return Error with correct quadKey and wrong version parameter", async () => {
         const dataRequest = new dataServiceRead.DataRequest()
             .withVersion(100500)

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -44,7 +44,7 @@ describe("VolatileLayerClient", () => {
     let getBaseUrlRequestStub: sinon.SinonStub;
     let volatileLayerClient: dataServiceRead.VolatileLayerClient;
     const mockedHRN = dataServiceRead.HRN.fromString(
-        "hrn:here:data:::live-weather-na"
+        "hrn:here:data:::mocked-hrn"
     );
     const mockedLayerId = "mocked-layed-id";
     const fakeURL = "http://fake-base.url";
@@ -395,7 +395,7 @@ describe("VolatileLayerClient", () => {
     it("Should method getData with wrong partitionId parameter and version return error", async () => {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedErrorResponse =
-            "No partition dataHandle for partition 42. HRN: hrn:here:data:::live-weather-na";
+            "No partition dataHandle for partition 42. HRN: hrn:here:data:::mocked-hrn";
         const mockedPartitionsIdData = {
             partitions: [
                 {
@@ -425,7 +425,7 @@ describe("VolatileLayerClient", () => {
             .getData((dataRequest as unknown) as dataServiceRead.DataRequest)
             .catch(error => {
                 assert.isDefined(error);
-                assert.equal(mockedErrorResponse, error);
+                assert.equal(mockedErrorResponse, error.message);
             });
     });
 


### PR DESCRIPTION
* Return HttpError with correct status and message for getData method with invalid partitionId in VersionLayerClient
* Return HttpError with correct status and message for getData method with invalid partitionId in VolatileLayerClient
* Update unit tests

Resolves: OLPEDGE-1491
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>