### PR TITLE
Propagate HttpError class in IndexLayer for getPartitions method.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
@@ -67,13 +67,13 @@ export class IndexLayerClient {
             return Promise.reject("Please provide correct query");
         }
 
-        const requestBilder = await this.getRequestBuilder(
+        const requestBuilder = await this.getRequestBuilder(
             "index",
             this.catalogHrn,
             abortSignal
         ).catch(err => Promise.reject(err));
 
-        const indexMetadata = await IndexApi.performQuery(requestBilder, {
+        const indexMetadata = await IndexApi.performQuery(requestBuilder, {
             layerID: this.layerId,
             query,
             huge: request.getHugeResponse()


### PR DESCRIPTION
Propagate HttpError class in IndexLayer for getPartitions method.
HttpError class provides to the consumers ability to error message and status from service.
Consolidating error handling strategy through all clients is a way to make it solid.

* Update error handling approach for getPartitions methods in IndexLayerClient.
* Update unit tests for IndexLayerClient.

Resolves: OLPEDGE-1437

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>