### PR TITLE
Add Unit tests for ApiCacheRepository.

### DIFF
--- a/@here/olp-sdk-dataservice-read/test/unit/ApiCacheRepository.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ApiCacheRepository.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import * as dataServiceRead from "../../lib";
+import { ApiCacheRepository, KeyValueCache } from "../../lib";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("ApiCacheRepository", () => {
+    let testCache = new KeyValueCache();
+    testCache.put("test-key", "test-value");
+    let apiCacheRepository = new ApiCacheRepository(testCache);
+
+    const testServiceApiName = "config";
+    const testServiceVersion = "service-version";
+    const testServiceUrl = "service-url";
+
+    const testServiceApiName2 = "metadata";
+    const testServiceVersion2 = "service-version2";
+    const testServiceUrl2 = "service-url2";
+
+    const testServiceApiName3 = "query";
+    const testServiceVersion3 = "service-version3";
+    const testServiceUrl3 = "service-url3";
+
+    it("Shoud be initialised", async () => {
+        assert.isDefined(apiCacheRepository);
+        expect(apiCacheRepository).be.instanceOf(
+            dataServiceRead.ApiCacheRepository
+        );
+    });
+
+    it("Method put should store a new key-value pair in the cache", async () => {
+        const operationIsSuccessful = apiCacheRepository.put(
+            testServiceApiName,
+            testServiceVersion,
+            testServiceUrl
+        );
+
+        expect(operationIsSuccessful).equal(true);
+        expect(
+            apiCacheRepository.get(testServiceApiName, testServiceVersion)
+        ).equal(testServiceUrl);
+    });
+
+    it("Method get should return the base URL from the cache.", async () => {
+        apiCacheRepository.put(
+            testServiceApiName2,
+            testServiceVersion2,
+            testServiceUrl2
+        );
+        apiCacheRepository.put(
+            testServiceApiName3,
+            testServiceVersion3,
+            testServiceUrl3
+        );
+
+        expect(
+            apiCacheRepository.get(testServiceApiName, testServiceVersion)
+        ).equal(testServiceUrl);
+        expect(
+            apiCacheRepository.get(testServiceApiName2, testServiceVersion2)
+        ).equal(testServiceUrl2);
+        expect(
+            apiCacheRepository.get(testServiceApiName3, testServiceVersion3)
+        ).equal(testServiceUrl3);
+    });
+});


### PR DESCRIPTION
* Add new Unit tests for ApiCacheRepository class.

* Update coverage of ApiCacheRepository class in dataservice-read to 100%.

Resolves: OLPEDGE-1477

Signed-off-by: Bautista, Iryna <ext-iryna.bautista@here.com>