### PR TITLE
Update VersionedLayerClient and VolatileLayerClient

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -122,15 +122,17 @@ export class VersionedLayerClient {
                     return Promise.reject(quadTreeIndexResponse);
                 }
 
-                return quadTreeIndexResponse.subQuads
+                return quadTreeIndexResponse.subQuads &&
+                    quadTreeIndexResponse.subQuads.length
                     ? this.downloadPartition(
                           quadTreeIndexResponse.subQuads[0].dataHandle,
                           abortSignal,
                           dataRequest.getBillingTag()
                       )
                     : Promise.reject(
-                          new Error(
-                              `No dataHandle for quadKey ${quadKey}. HRN: ${this.hrn}`
+                          new HttpError(
+                              204,
+                              `No dataHandle for quadKey {column: ${quadKey.column}, row: ${quadKey.row}, level: ${quadKey.level}}. HRN: ${this.hrn}`
                           )
                       );
             }

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -119,15 +119,16 @@ export class VolatileLayerClient {
                     return Promise.reject(quadTreeIndex);
                 }
 
-                return quadTreeIndex.subQuads
+                return quadTreeIndex.subQuads && quadTreeIndex.subQuads.length
                     ? this.downloadPartition(
                           quadTreeIndex.subQuads[0].dataHandle,
                           abortSignal,
                           dataRequest.getBillingTag()
                       )
                     : Promise.reject(
-                          new Error(
-                              `No dataHandle for quadKey ${quadKey}. HRN: ${this.hrn}`
+                          new HttpError(
+                              204,
+                              `No dataHandle for quadKey {column: ${quadKey.column}, row: ${quadKey.row}, level: ${quadKey.level}}. HRN: ${this.hrn}`
                           )
                       );
             }

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -334,6 +334,34 @@ describe("VersionedLayerClient", () => {
             });
     });
 
+    it("Should method getData return Error with incorrect quadKey", async () => {
+        const errorMessage =
+            "No dataHandle for quadKey {column: 15, row: 1, level: 5}. HRN: hrn:here:data:::mocked-hrn";
+        const ERROR_STATUS = 204;
+        const mockedQuadKeyTreeData = {
+            subQuads: [],
+            parentQuads: []
+        };
+
+        getQuadTreeIndexStub.callsFake(
+            (builder: any, params: any): Promise<QueryApi.Index> => {
+                return Promise.resolve(mockedQuadKeyTreeData);
+            }
+        );
+
+        const dataRequest = new dataServiceRead.DataRequest()
+            .withQuadKey(dataServiceRead.quadKeyFromMortonCode("1111"))
+            .withVersion(42);
+
+        const response = await versionedLayerClient
+            .getData((dataRequest as unknown) as dataServiceRead.DataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(error.message, errorMessage);
+                assert.equal(error.status, ERROR_STATUS);
+            });
+    });
+
     it("Should be aborted fetching by abort signal", async () => {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedPartitionsIdData = {

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -603,6 +603,46 @@ describe("VolatileLayerClient", () => {
             });
     });
 
+    it("Should method getData return Error with incorrect quadKey", async () => {
+        const errorMessage =
+            "No dataHandle for quadKey {column: 15, row: 1, level: 5}. HRN: hrn:here:data:::mocked-hrn";
+        const ERROR_STATUS = 204;
+        const mockedQuadKeyTreeData = {
+            subQuads: [],
+            parentQuads: []
+        };
+        const mockedVersion = {
+            version: 42
+        };
+
+        getQuadTreeIndexStub.callsFake(
+            (builder: any, params: any): Promise<QueryApi.Index> => {
+                return Promise.resolve(mockedQuadKeyTreeData);
+            }
+        );
+
+        getVersionStub.callsFake(
+            (
+                builder: any,
+                params: any
+            ): Promise<MetadataApi.VersionResponse> => {
+                return Promise.resolve(mockedVersion);
+            }
+        );
+
+        const dataRequest = new dataServiceRead.DataRequest().withQuadKey(
+            dataServiceRead.quadKeyFromMortonCode("1111")
+        );
+
+        const response = await volatileLayerClient
+            .getData((dataRequest as unknown) as dataServiceRead.DataRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(error.message, errorMessage);
+                assert.equal(error.status, ERROR_STATUS);
+            });
+    });
+
     it("Should baseUrl error be handled", async () => {
         const mockedErrorResponse = "Bad response";
         const dataRequest = new dataServiceRead.DataRequest().withDataHandle(


### PR DESCRIPTION
* Update error handling strategy in the getData method for incorrect quadKey for VersionedLayerClient and VolatileLayerClient
* Add unit tests to handle mentioned cases

Resolves: OLPSUP-9376
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>