### PR TITLE
Create an overloaded constructor for VersionedLayerClient.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/DataRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/DataRequest.ts
@@ -92,6 +92,9 @@ export class DataRequest {
     }
 
     /**
+     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * initialize the version client with not deprecated constructor, in other case the latest version will be used.
+     *
      * Gets a catalog version for the request.
      *
      * @return The catalog version number.
@@ -101,6 +104,9 @@ export class DataRequest {
     }
 
     /**
+     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * initialize the version client with not deprecated constructor, in other case the latest version will be used.
+     *
      * Sets the provided catalog version.
      *
      * @param version The catalog version number.

--- a/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
@@ -30,6 +30,9 @@ export class PartitionsRequest {
     private additionalFields?: AdditionalFields;
 
     /**
+     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * initialize the version client with not deprecated constructor, in other case the latest version will be used.
+     *
      * Gets a layer version for the request.
      *
      * @return The layer version number.
@@ -39,6 +42,9 @@ export class PartitionsRequest {
     }
 
     /**
+     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * initialize the version client with not deprecated constructor, in other case the latest version will be used.
+     *
      * An optional method that sets the provided layer version.
      * If the layer version is not specified, the last layer version is used.
      *
@@ -103,7 +109,9 @@ export class PartitionsRequest {
      *
      * @returns The updated [[PartitionsRequest]] instance that you can use to chain methods.
      */
-    public withAdditionalFields(additionalFields: AdditionalFields): PartitionsRequest {
+    public withAdditionalFields(
+        additionalFields: AdditionalFields
+    ): PartitionsRequest {
         this.additionalFields = additionalFields;
         return this;
     }

--- a/@here/olp-sdk-dataservice-read/lib/client/QuadKeyPartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QuadKeyPartitionsRequest.ts
@@ -33,6 +33,9 @@ export class QuadKeyPartitionsRequest {
     private additionalFields?: AdditionalFields;
 
     /**
+     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * initialize the version client with not deprecated constructor, in other case the latest version will be used.
+     *
      * The version of the catalog against which you want to run the query.
      * It must be a valid catalog version.
      *
@@ -99,6 +102,9 @@ export class QuadKeyPartitionsRequest {
     }
 
     /**
+     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * initialize the version client with not deprecated constructor, in other case the latest version will be used.
+     *
      * The configured catalog version for the request.
      *
      * @return The catalog version number.

--- a/docs/examples/nodejs-read-versioned-layer.md
+++ b/docs/examples/nodejs-read-versioned-layer.md
@@ -153,13 +153,16 @@ To create the `VersionedLayerClient` object:
 2. Create the `OlpClientSettings` object.
    For instructions, see [Create OlpClientSettings](#create-olpclientsettings).
 
-3. Create the `VersionedLayerClient` object with the HERE Resource Name (HRN) of the catalog that contains the layer, the layer ID, and the OLP client settings from step 2.
+3.  Create an [[VersionedLayerClient]] instance with VersionedLayerClientParams that contains the catalog HRN, the layer ID, the OLP client settings from step 2 and layer version. If layer version is not defined, then latest version will be used.
 
    ```typescript
-   const versionedLayerClient = await new VersionedLayerClient()
-       hrn: "CatalogHRN",
-       layerId: "LayerId",
-       olpClientSettings
+   const versionedLayerClient = new VersionedLayerClient(
+      {
+         catalogHrn: "CatalogHRN",
+         layerId: "LayerId",
+         settings: olpClientSettings,
+         version: 5
+      }
    );
    ```
 

--- a/tests/integration/VersionedLayerClient.test.ts
+++ b/tests/integration/VersionedLayerClient.test.ts
@@ -73,6 +73,43 @@ describe("VersionedLayerClient", () => {
     expect(layerClient).to.be.instanceOf(VersionedLayerClient);
   });
 
+  it("Shoud be initialised with VersionedLayerClientParams with version", async () => {
+    const settings = new OlpClientSettings({
+      environment: "here",
+      getToken: () => Promise.resolve("test-token-string")
+    });
+
+    const versionedLayerClientParams = {
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: settings,
+      version: 5
+    };
+    const layerClientWithVersion = new VersionedLayerClient(
+      versionedLayerClientParams
+    );
+    assert.isDefined(layerClientWithVersion);
+    expect(layerClientWithVersion).to.be.instanceOf(VersionedLayerClient);
+  });
+
+  it("Shoud be initialised with VersionedLayerClientParams without version", async () => {
+    const settings = new OlpClientSettings({
+      environment: "here",
+      getToken: () => Promise.resolve("test-token-string")
+    });
+
+    const versionedLayerClientParams = {
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: settings
+    };
+    const layerClientWithoutVersion = new VersionedLayerClient(
+      versionedLayerClientParams
+    );
+    assert.isDefined(layerClientWithoutVersion);
+    expect(layerClientWithoutVersion).to.be.instanceOf(VersionedLayerClient);
+  });
+
   it("Shoud be fetched partitions metadata for specific IDs", async () => {
     const mockedResponses = new Map();
 
@@ -124,6 +161,30 @@ describe("VersionedLayerClient", () => {
       )
     );
 
+    mockedResponses.set(
+      `https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::test-hrn/apis/metadata/v1`,
+      new Response(
+        JSON.stringify([
+          {
+            api: "metadata",
+            version: "v1",
+            baseURL: "https://metadata.data.api.platform.here.com/metadata/v1",
+            parameters: {
+              additionalProp1: "string",
+              additionalProp2: "string",
+              additionalProp3: "string"
+            }
+          }
+        ])
+      )
+    );
+
+    // Set the response from Metadata service with the info about latest catalog version.
+    mockedResponses.set(
+      `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
+      new Response(JSON.stringify({ version: 128 }))
+    );
+
     // Setup the fetch to use mocked responses.
     fetchMock.withMockedResponses(mockedResponses);
 
@@ -163,7 +224,7 @@ describe("VersionedLayerClient", () => {
        * Check if the count of requests are as expected. Should be called 2 times. One to the lookup service
        * for the baseURL to the Query service and another one to the query service.
        */
-      expect(fetchStub.callCount).to.be.equal(2);
+      expect(fetchStub.callCount).to.be.equal(4);
     }
   });
 
@@ -317,6 +378,30 @@ describe("VersionedLayerClient", () => {
       new Response(mockedData)
     );
 
+    mockedResponses.set(
+      `https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::test-hrn/apis/metadata/v1`,
+      new Response(
+        JSON.stringify([
+          {
+            api: "metadata",
+            version: "v1",
+            baseURL: "https://metadata.data.api.platform.here.com/metadata/v1",
+            parameters: {
+              additionalProp1: "string",
+              additionalProp2: "string",
+              additionalProp3: "string"
+            }
+          }
+        ])
+      )
+    );
+
+    // Set the response from Metadata service with the info about latest catalog version.
+    mockedResponses.set(
+      `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
+      new Response(JSON.stringify({ version: 128 }))
+    );
+
     // Setup the fetch to use mocked responses.
     fetchMock.withMockedResponses(mockedResponses);
 
@@ -334,7 +419,7 @@ describe("VersionedLayerClient", () => {
     const data = await layerClient.getData(request);
 
     assert.isDefined(data);
-    expect(fetchStub.callCount).to.be.equal(2);
+    expect(fetchStub.callCount).to.be.equal(4);
   });
 
   it("Shoud be fetched data with PartitionId", async () => {
@@ -517,6 +602,30 @@ describe("VersionedLayerClient", () => {
       new Response(mockedData)
     );
 
+    mockedResponses.set(
+      `https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::test-hrn/apis/metadata/v1`,
+      new Response(
+        JSON.stringify([
+          {
+            api: "metadata",
+            version: "v1",
+            baseURL: "https://metadata.data.api.platform.here.com/metadata/v1",
+            parameters: {
+              additionalProp1: "string",
+              additionalProp2: "string",
+              additionalProp3: "string"
+            }
+          }
+        ])
+      )
+    );
+
+    // Set the response from Metadata service with the info about latest catalog version.
+    mockedResponses.set(
+      `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
+      new Response(JSON.stringify({ version: 42 }))
+    );
+
     // Setup the fetch to use mocked responses.
     fetchMock.withMockedResponses(mockedResponses);
 
@@ -536,7 +645,7 @@ describe("VersionedLayerClient", () => {
     const data = await layerClient.getData(request);
 
     assert.isDefined(data);
-    expect(fetchStub.callCount).to.be.equal(4);
+    expect(fetchStub.callCount).to.be.equal(6);
   });
 
   it("Shoud be fetched data with QuadKey", async () => {
@@ -723,6 +832,30 @@ describe("VersionedLayerClient", () => {
       new Response(mockedData)
     );
 
+    mockedResponses.set(
+      `https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::test-hrn/apis/metadata/v1`,
+      new Response(
+        JSON.stringify([
+          {
+            api: "metadata",
+            version: "v1",
+            baseURL: "https://metadata.data.api.platform.here.com/metadata/v1",
+            parameters: {
+              additionalProp1: "string",
+              additionalProp2: "string",
+              additionalProp3: "string"
+            }
+          }
+        ])
+      )
+    );
+
+    // Set the response from Metadata service with the info about latest catalog version.
+    mockedResponses.set(
+      `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
+      new Response(JSON.stringify({ version: 42 }))
+    );
+
     // Setup the fetch to use mocked responses.
     fetchMock.withMockedResponses(mockedResponses);
 
@@ -742,7 +875,7 @@ describe("VersionedLayerClient", () => {
     const data = await layerClient.getData(request);
 
     assert.isDefined(data);
-    expect(fetchStub.callCount).to.be.equal(4);
+    expect(fetchStub.callCount).to.be.equal(6);
   });
 
   it("Shoud read partitions metadata by QuadKey for specific VersionLayer", async () => {
@@ -807,6 +940,29 @@ describe("VersionedLayerClient", () => {
           ]
         })
       )
+    );
+
+    mockedResponses.set(
+      `https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::test-hrn/apis/metadata/v1`,
+      new Response(
+        JSON.stringify([
+          {
+            api: "metadata",
+            version: "v1",
+            baseURL: "https://metadata.data.api.platform.here.com/metadata/v1",
+            parameters: {
+              additionalProp1: "string",
+              additionalProp2: "string",
+              additionalProp3: "string"
+            }
+          }
+        ])
+      )
+    );
+
+    mockedResponses.set(
+      `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1&billingTag=billingTag`,
+      new Response(JSON.stringify({ version: 42 }))
     );
 
     // Setup the fetch to use mocked responses.


### PR DESCRIPTION
Create interface VersionedLayerClientParams old params and an optional parameter version.

Mark current constructor as deprecated.

Update Unit tests for VersionedLayerClient class and add new.

Add new Unit tests with VersionedLayerClient new instance.

Add new integration tests with VersionedLayerClient new instance.

Resolves: OLPEDGE-1534

Signed-off-by: Drapak Iryna Angelica ext-iryna.drapak@here.com