### PR TITLE
Make "datalevel" is not required in statistics API

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/coverage-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/coverage-api.ts
@@ -130,7 +130,7 @@ export async function getDataCoverageAdminAreas(
  */
 export async function getDataCoverageSizeMap(
     builder: RequestBuilder,
-    params: { layerId: string; datalevel: string }
+    params: { layerId: string; datalevel?: number }
 ): Promise<Response> {
     const baseUrl = "/layers/{layerId}/heatmap/size".replace(
         "{layerId}",
@@ -185,7 +185,7 @@ export async function getDataCoverageSummary(
  */
 export async function getDataCoverageTile(
     builder: RequestBuilder,
-    params: { layerId: string; datalevel: string }
+    params: { layerId: string; datalevel?: number }
 ): Promise<Response> {
     const baseUrl = "/layers/{layerId}/tilemap".replace(
         "{layerId}",
@@ -213,7 +213,7 @@ export async function getDataCoverageTile(
  */
 export async function getDataCoverageTimeMap(
     builder: RequestBuilder,
-    params: { layerId: string; datalevel: string; catalogHRN: string }
+    params: { layerId: string; datalevel?: number; catalogHRN: string }
 ): Promise<Response> {
     const baseUrl = "/layers/{layerId}/heatmap/age".replace(
         "{layerId}",

--- a/@here/olp-sdk-dataservice-read/lib/client/StatisticsClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StatisticsClient.ts
@@ -99,9 +99,6 @@ export class StatisticsClient {
         if (typemap === undefined) {
             return Promise.reject(new Error(`No typemap provided`));
         }
-        if (datalevel === undefined) {
-            return Promise.reject(new Error(`No dataLevel provided`));
-        }
         const coverageRequestBuilder = await this.getRequestBuilder(
             catalogHRN
         ).catch(error => Promise.reject(error));

--- a/@here/olp-sdk-dataservice-read/lib/client/StatisticsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StatisticsRequest.ts
@@ -38,7 +38,7 @@ export class StatisticsRequest {
     private catalogHrn?: string;
     private layerId?: string;
     private typemap?: CoverageDataType;
-    private dataLevel?: string;
+    private dataLevel?: number;
     private billingTag?: string;
 
     /**
@@ -71,12 +71,19 @@ export class StatisticsRequest {
     /**
      * Gets a tile level for the request.
      *
+     * @return The requested tile level number.
+     */
+    public getDataLevel(): number | undefined;
+
+    /**
+     * Gets a tile level for the request.
+     * @deprecated Please use getDataLevel(): number | undefined
      * @return The requested tile level string.
      */
-    public getDataLevel(): string | undefined {
+    public getDataLevel(): string | undefined;
+    public getDataLevel(): number | string | undefined {
         return this.dataLevel;
     }
-
     /**
      * A setter for the provided catalog HERE Resource Name (HRN).
      *
@@ -114,13 +121,26 @@ export class StatisticsRequest {
     }
 
     /**
-     * A setter for the provided `dataLevel` string.
+     * A setter for the provided `dataLevel`.
      *
-     * @param dataLevel Specify the tile level about which you want to get statistical data.
+     * @param dataLevel By default, assets generated at deepest data level are returned.
+     * Note that assets returned for data levels greater than 11 represent data at data level 11.
      * @returns The updated [[StatisticsRequest]] instance that you can use to chain methods.
      */
-    public withDataLevel(dataLevel: string): StatisticsRequest {
-        this.dataLevel = dataLevel;
+    public withDataLevel(dataLevel: number): StatisticsRequest;
+
+    /**
+     * A setter for the provided `dataLevel` string.
+     *
+     * @deprecated Please set dataLevel as a number
+     * @param dataLevel dataLevel Specify the tile level about which you want to get statistical data.
+     * @returns The updated [[StatisticsRequest]] instance that you can use to chain methods.
+     */
+    // tslint:disable-next-line: unified-signatures
+    public withDataLevel(dataLevel: string): StatisticsRequest;
+
+    public withDataLevel(dataLevel: string | number) {
+        this.dataLevel = Number(dataLevel);
         return this;
     }
 

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
@@ -30,9 +30,7 @@ const assert = chai.assert;
 
 describe("StatistiscClient", () => {
     let sandbox: sinon.SinonSandbox;
-    let olpClientSettingsStub: sinon.SinonStubbedInstance<
-        dataServiceRead.OlpClientSettings
-    >;
+    let olpClientSettingsStub: sinon.SinonStubbedInstance<dataServiceRead.OlpClientSettings>;
     let getDataCoverageSummaryStub: sinon.SinonStub;
     let getStatisticsBitMapStub: sinon.SinonStub;
     let getStatisticsSizeMapStub: sinon.SinonStub;
@@ -134,10 +132,12 @@ describe("StatistiscClient", () => {
         );
         assert.isDefined(statisticsClient);
 
-        const summaryRequest = new dataServiceRead.SummaryRequest()
-            .withLayerId(mockedLayerId);
+        const summaryRequest = new dataServiceRead.SummaryRequest().withLayerId(
+            mockedLayerId
+        );
 
-        const summary = await statisticsClient.getSummary(summaryRequest)
+        const summary = await statisticsClient
+            .getSummary(summaryRequest)
             .catch(error => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error.message);
@@ -151,10 +151,12 @@ describe("StatistiscClient", () => {
         );
         assert.isDefined(statisticsClient);
 
-        const summaryRequest = new dataServiceRead.SummaryRequest()
-            .withCatalogHrn(mockedHRN);
+        const summaryRequest = new dataServiceRead.SummaryRequest().withCatalogHrn(
+            mockedHRN
+        );
 
-        const summary = await statisticsClient.getSummary(summaryRequest)
+        const summary = await statisticsClient
+            .getSummary(summaryRequest)
             .catch(error => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error.message);
@@ -186,7 +188,7 @@ describe("StatistiscClient", () => {
         const statisticBitMapRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
-            .withDataLevel("12")
+            .withDataLevel(12)
             .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
 
         const statisticBitMap = await statisticsClient.getStatistics(
@@ -197,7 +199,7 @@ describe("StatistiscClient", () => {
         const statisticSizeMapRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
-            .withDataLevel("12")
+            .withDataLevel(12)
             .withTypemap(dataServiceRead.CoverageDataType.SIZEMAP);
 
         const statisticSizeMap = await statisticsClient.getStatistics(
@@ -208,7 +210,7 @@ describe("StatistiscClient", () => {
         const statisticTimeMapRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
-            .withDataLevel("12")
+            .withDataLevel(12)
             .withTypemap(dataServiceRead.CoverageDataType.TIMEMAP);
 
         const statisticTimeMap = await statisticsClient.getStatistics(
@@ -226,15 +228,15 @@ describe("StatistiscClient", () => {
 
         const statisticRequest = new dataServiceRead.StatisticsRequest()
             .withLayerId(mockedLayerId)
-            .withDataLevel("12")
+            .withDataLevel(12)
             .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
 
-        const statistic = await statisticsClient.getStatistics(
-            statisticRequest
-        ).catch(error => {
-            assert.isDefined(error);
-            assert.equal(mockedErrorResponse, error.message);
-        });
+        const statistic = await statisticsClient
+            .getStatistics(statisticRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.message);
+            });
     });
 
     it("Should method getStatistics return error if layerId is not provided", async () => {
@@ -246,35 +248,15 @@ describe("StatistiscClient", () => {
 
         const statisticRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
-            .withDataLevel("12")
+            .withDataLevel(12)
             .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
 
-        const statistic = await statisticsClient.getStatistics(
-            statisticRequest
-        ).catch(error => {
-            assert.isDefined(error);
-            assert.equal(mockedErrorResponse, error.message);
-        });
-    });
-
-    it("Should method getStatistics return error if dataLevel is not provided", async () => {
-        const mockedErrorResponse = "No dataLevel provided";
-        const statisticsClient = new dataServiceRead.StatisticsClient(
-            olpClientSettingsStub as any
-        );
-        assert.isDefined(statisticsClient);
-
-        const statisticRequest = new dataServiceRead.StatisticsRequest()
-            .withCatalogHrn(mockedHRN)
-            .withLayerId(mockedLayerId)
-            .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
-
-        const statistic = await statisticsClient.getStatistics(
-            statisticRequest
-        ).catch(error => {
-            assert.isDefined(error);
-            assert.equal(mockedErrorResponse, error.message);
-        });
+        const statistic = await statisticsClient
+            .getStatistics(statisticRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.message);
+            });
     });
 
     it("Should method getStatistics return error if typemap is not provided", async () => {
@@ -287,13 +269,66 @@ describe("StatistiscClient", () => {
         const statisticRequest = new dataServiceRead.StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)
-            .withDataLevel("12");
+            .withDataLevel(12);
 
-        const statistic = await statisticsClient.getStatistics(
-            statisticRequest
-        ).catch(error => {
-            assert.isDefined(error);
-            assert.equal(mockedErrorResponse, error.message);
-        });
+        const statistic = await statisticsClient
+            .getStatistics(statisticRequest)
+            .catch(error => {
+                assert.isDefined(error);
+                assert.equal(mockedErrorResponse, error.message);
+            });
+    });
+
+    it("Should method getStatistics provide data if dataLevel not set", async () => {
+        const mockedStatistics: Response = new Response("mocked-response");
+        const statisticsClient = new dataServiceRead.StatisticsClient(
+            olpClientSettingsStub as any
+        );
+        assert.isDefined(statisticsClient);
+        getStatisticsBitMapStub.callsFake(
+            (builder: any, params: any): Promise<Response> => {
+                return Promise.resolve(mockedStatistics);
+            }
+        );
+        getStatisticsSizeMapStub.callsFake(
+            (builder: any, params: any): Promise<Response> => {
+                return Promise.resolve(mockedStatistics);
+            }
+        );
+        getStatisticsTimeMapStub.callsFake(
+            (builder: any, params: any): Promise<Response> => {
+                return Promise.resolve(mockedStatistics);
+            }
+        );
+
+        const statisticBitMapRequest = new dataServiceRead.StatisticsRequest()
+            .withCatalogHrn(mockedHRN)
+            .withLayerId(mockedLayerId)
+            .withTypemap(dataServiceRead.CoverageDataType.BITMAP);
+
+        const statisticBitMap = await statisticsClient.getStatistics(
+            statisticBitMapRequest
+        );
+        assert.isDefined(statisticBitMap);
+
+        const statisticSizeMapRequest = new dataServiceRead.StatisticsRequest()
+            .withCatalogHrn(mockedHRN)
+            .withLayerId(mockedLayerId)
+            .withTypemap(dataServiceRead.CoverageDataType.SIZEMAP);
+
+        const statisticSizeMap = await statisticsClient.getStatistics(
+            statisticSizeMapRequest
+        );
+        assert.isDefined(statisticSizeMap);
+
+        const statisticTimeMapRequest = new dataServiceRead.StatisticsRequest()
+            .withCatalogHrn(mockedHRN)
+            .withLayerId(mockedLayerId)
+            .withTypemap(dataServiceRead.CoverageDataType.TIMEMAP);
+
+        const statisticTimeMap = await statisticsClient.getStatistics(
+            statisticTimeMapRequest
+        );
+        assert.isDefined(statisticTimeMap);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsRequest.test.ts
@@ -32,7 +32,7 @@ describe("SummaryRequest", () => {
     const billingTag = "billingTag";
     const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
     const mockedLayerId = "mocked-layed-id";
-    const mockedDataLevel = "42";
+    const mockedDataLevel = 9;
     const mockedTimemap = CoverageDataType.TIMEMAP;
 
     it("Should initialize", () => {
@@ -44,17 +44,37 @@ describe("SummaryRequest", () => {
 
     it("Should set parameters", () => {
         const statisticsRequest = new StatisticsRequest();
-        const statisticsRequestWithCatalogHrn = statisticsRequest.withCatalogHrn(mockedHRN);
-        const statisticsRequestWithLayerId = statisticsRequest.withLayerId(mockedLayerId);
-        const statisticsRequestWithDataLevel = statisticsRequest.withDataLevel(mockedDataLevel);
-        const statisticsRequestWithTimemap = statisticsRequest.withTypemap(mockedTimemap);
-        const statisticsRequestWithBillTag = statisticsRequest.withBillingTag(billingTag);
+        const statisticsRequestWithCatalogHrn = statisticsRequest.withCatalogHrn(
+            mockedHRN
+        );
+        const statisticsRequestWithLayerId = statisticsRequest.withLayerId(
+            mockedLayerId
+        );
+        const statisticsRequestWithDataLevel = statisticsRequest.withDataLevel(
+            mockedDataLevel
+        );
+        const statisticsRequestWithTimemap = statisticsRequest.withTypemap(
+            mockedTimemap
+        );
+        const statisticsRequestWithBillTag = statisticsRequest.withBillingTag(
+            billingTag
+        );
 
-        expect(statisticsRequestWithCatalogHrn.getCatalogHrn()).to.be.equal(mockedHRN.toString());
-        expect(statisticsRequestWithLayerId.getLayerId()).to.be.equal(mockedLayerId);
-        expect(statisticsRequestWithDataLevel.getDataLevel()).to.be.equal(mockedDataLevel);
-        expect(statisticsRequestWithTimemap.getTypemap()).to.be.equal(mockedTimemap);
-        expect(statisticsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
+        expect(statisticsRequestWithCatalogHrn.getCatalogHrn()).to.be.equal(
+            mockedHRN.toString()
+        );
+        expect(statisticsRequestWithLayerId.getLayerId()).to.be.equal(
+            mockedLayerId
+        );
+        expect(statisticsRequestWithDataLevel.getDataLevel()).to.be.equal(
+            mockedDataLevel
+        );
+        expect(statisticsRequestWithTimemap.getTypemap()).to.be.equal(
+            mockedTimemap
+        );
+        expect(statisticsRequestWithBillTag.getBillingTag()).to.be.equal(
+            billingTag
+        );
     });
 
     it("Should get parameters with chain", () => {
@@ -65,7 +85,9 @@ describe("SummaryRequest", () => {
             .withTypemap(mockedTimemap)
             .withBillingTag(billingTag);
 
-        expect(statisticsRequest.getCatalogHrn()).to.be.equal(mockedHRN.toString());
+        expect(statisticsRequest.getCatalogHrn()).to.be.equal(
+            mockedHRN.toString()
+        );
         expect(statisticsRequest.getLayerId()).to.be.equal(mockedLayerId);
         expect(statisticsRequest.getDataLevel()).to.be.equal(mockedDataLevel);
         expect(statisticsRequest.getTypemap()).to.be.equal(mockedTimemap);


### PR DESCRIPTION
Datalevel is not required now, de to changes in the statistics service.
When using API to retrieve assets, if no data level is provided, you get back assets at the deepest data level this layer is configured for.

Also, change the type of datalevel from string to number (supports levels 0-11) and add one more test to check methods if no datalevel provided.

Resolves OLPSUP-9319

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>