### PR TITLE
Fix path for typings.

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -4,7 +4,7 @@
   "description": "Wrapper around the HERE Authentication and Authorization REST API obtaining short-lived access tokens that are used to authenticate requests to HERE services.",
   "main": "index.js",
   "browser": "index.web.js",
-  "typings": "index.web",
+  "typings": "index",
   "directories": {
     "test": "test",
     "lib": "lib"


### PR DESCRIPTION
Fixing typings path.

The code like:
`import {
    loadCredentialsFromFile
} from "@here/olp-sdk-authentication";`

was not be able to compile in plain typescript project.

Relates: OLPEDGE-1552

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>