### PR TITLE
Create an overloaded constructor for VolatileLayerClient.

### DIFF
--- a/@here/olp-sdk-dataservice-api/README.md
+++ b/@here/olp-sdk-dataservice-api/README.md
@@ -42,6 +42,6 @@ Add minified JavaScript files to your `html`:
 
 ## LICENSE
 
-Copyright (C) 2019 HERE Europe B.V.
+Copyright (C) 2019-2020 HERE Europe B.V.
 
 For license details, see the [LICENSE](LICENSE).

--- a/@here/olp-sdk-dataservice-read/README.md
+++ b/@here/olp-sdk-dataservice-read/README.md
@@ -90,19 +90,20 @@ Add minified JavaScript files to your `html` and create an object of userAuth an
                 tokenRequester: requestToken
             });
             /**
-             * Create DatastoreContext with olp-sdk-dataservice-read
+             * Create the `OlpClientSettings` object
              */
-            const context = new DataStoreContext({
-                environment: "here",
+            const olpClientSettings = new OlpClientSettings({
+                environment:
+                "here | here-dev | here-cn | here-cn-dev | http://YourCustomEnvironment",
                 getToken: () => userAuth.getToken()
             });
             /**
-             * Create client to the volatile layer with olp-sdk-dataservice-read
+             * Create client to the volatile layer with VolatileLayerClientParams
              */
             const volatileLayerClient = new VolatileLayerClient({
-                context,
-                hrn: "your-catalog-hrn",
-                layerId: "your-layer-id"
+                    catalogHrn: "CatalogHRN",
+                    layerId: "LayerId",
+                    settings: olpClientSettings
             });
             /**
              * Get some partition from the layer by ID

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,29 +37,69 @@ import {
 } from "..";
 
 /**
+ * Parameters for use to initialize VolatileLayerClient.
+ */
+export interface VolatileLayerClientParams {
+    // HRN of the catalog.
+    catalogHrn: HRN;
+    // The ID of the layer.
+    layerId: string;
+    // The [[OlpClientSettings]] instance.
+    settings: OlpClientSettings;
+}
+
+/**
  * Describes a voaltile layer and provides the possibility to get partitions metadata and data.
  */
 export class VolatileLayerClient {
     private readonly apiVersion: string = "v1";
-    /** The HERE Resource Name (HRN) of the layer. */
-    readonly hrn: string;
+
+    // The HERE Resource Name of the catalog
+    private hrn: string;
+    // The ID of the layer.
+    private layerId: string;
+    // The [[OlpClientSettings]] instance.
+    private settings: OlpClientSettings;
 
     /**
+     * @deprecated Please use the overloaded constructor of VolatileLayerClient.
+     *
      * Creates the [[VolatileLayerClient]] instance.
      *
      * @param catalogHrn The HERE Resource Name of the catalog from which you want to get partitions metadata and data.
      * @param layerId The ID of the layer.
      * @param settings The [[OlpClientSettings]] instance.
-     * @return The [[VolatileLayerClient]] instance.
+     */
+    constructor(catalogHrn: HRN, layerId: string, settings: OlpClientSettings);
+
+    /**
+     * Creates the [[VolatileLayerClient]] instance with VolatileLayerClientParams.
+     *
+     * @param params parameters for use to initialize VolatileLayerClient.
+     */
+    constructor(params: VolatileLayerClientParams);
+
+    /**
+     * Implementation for handling both constuctors.
      */
     constructor(
-        catalogHrn: HRN,
-        // The ID of the layer.
-        readonly layerId: string,
-        // The [[OlpClientSettings]] instance.
-        readonly settings: OlpClientSettings
+        paramsOrHrn: VolatileLayerClientParams | HRN,
+        layerId?: string,
+        settings?: OlpClientSettings
     ) {
-        this.hrn = catalogHrn.toString();
+        if (paramsOrHrn instanceof HRN) {
+            this.hrn = paramsOrHrn.toString();
+            if (layerId && settings instanceof OlpClientSettings) {
+                this.layerId = layerId;
+                this.settings = settings;
+            } else {
+                throw new Error("Unsupported parameters");
+            }
+        } else {
+            this.hrn = paramsOrHrn.catalogHrn.toString();
+            this.layerId = paramsOrHrn.layerId;
+            this.settings = paramsOrHrn.settings;
+        }
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ describe("VolatileLayerClient", () => {
     let getQuadTreeIndexStub: sinon.SinonStub;
     let getBaseUrlRequestStub: sinon.SinonStub;
     let volatileLayerClient: dataServiceRead.VolatileLayerClient;
+    let volatileLayerClientNew: dataServiceRead.VolatileLayerClient;
     const mockedHRN = dataServiceRead.HRN.fromString(
         "hrn:here:data:::mocked-hrn"
     );
@@ -58,6 +59,15 @@ describe("VolatileLayerClient", () => {
             mockedHRN,
             mockedLayerId,
             (settings as unknown) as dataServiceRead.OlpClientSettings
+        );
+
+        const volatileLayerClientParams = {
+            catalogHrn: mockedHRN,
+            layerId: mockedLayerId,
+            settings: (settings as unknown) as dataServiceRead.OlpClientSettings
+        };
+        volatileLayerClientNew = new dataServiceRead.VolatileLayerClient(
+            volatileLayerClientParams
         );
     });
 
@@ -78,7 +88,7 @@ describe("VolatileLayerClient", () => {
         sandbox.restore();
     });
 
-    it("Shoud be initialised", async () => {
+    it("Shoud be initialized", async () => {
         assert.isDefined(volatileLayerClient);
     });
 
@@ -713,5 +723,31 @@ describe("VolatileLayerClient", () => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error.statusText);
             });
+    });
+
+    it("VolatileLayerClient instance should be initialized with VolatileLayerClientParams", async () => {
+        assert.isDefined(volatileLayerClientNew);
+        assert.equal(
+            volatileLayerClientNew["hrn"],
+            "hrn:here:data:::mocked-hrn"
+        );
+    });
+
+    it("VolatileLayerClient should throw Error when setted unsuported parameters", async () => {
+        let settings1 = sandbox.createStubInstance(
+            dataServiceRead.OlpClientSettings
+        );
+
+        assert.throws(
+            () => {
+                new dataServiceRead.VolatileLayerClient(
+                    mockedHRN,
+                    "",
+                    (settings1 as unknown) as dataServiceRead.OlpClientSettings
+                );
+            },
+            Error,
+            "Unsupported parameters"
+        );
     });
 });

--- a/docs/examples/nodejs-read-volatile-layer.md
+++ b/docs/examples/nodejs-read-volatile-layer.md
@@ -153,13 +153,15 @@ To create the `VolatileLayerClient` object:
 2. Create the `OlpClientSettings` object.
    For instructions, see [Create OlpClientSettings](#create-olpclientsettings).
 
-3. Create the `VolatileLayerClient` object with the HERE Resource Name (HRN) of the catalog that contains the layer, the layer ID, and the OLP client settings.
+3. Create the `VolatileLayerClient` object with VolatileLayerClientParams that contains the HERE Resource Name (HRN) of the catalog, the layer ID, and the OLP client settings from step 2.
 
-   ```typescript
-   const volatileLayerClient = await new VolatileLayerClient()
-       hrn: "CatalogHRN",
-       layerId: "LayerId",
-       olpClientSettings
+   ```typescript   
+   const volatileLayerClient = new VolatileLayerClient(
+      {
+         catalogHrn: "CatalogHRN",
+         layerId: "LayerId",
+         settings: olpClientSettings
+      }
    );
    ```
 

--- a/tests/integration/VolatileLayerClient.test.ts
+++ b/tests/integration/VolatileLayerClient.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -844,5 +844,25 @@ describe("VolatileLayerClient", () => {
     );
 
     assert.isDefined(partitions);
+  });
+
+  it("Shoud be initialized with VolatileLayerClientParams", async () => {
+    const settings = new OlpClientSettings({
+      environment: "here",
+      getToken: () => Promise.resolve("test-token-string")
+    });
+
+    const volatileLayerClientParams = {
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: settings
+    };
+    const volatileLayerClient = new VolatileLayerClient(
+      volatileLayerClientParams
+    );
+
+    assert.isDefined(volatileLayerClient);
+    expect(volatileLayerClient).to.be.instanceOf(VolatileLayerClient);
+    assert.equal(volatileLayerClient["hrn"], "hrn:here:data:::test-hrn");
   });
 });


### PR DESCRIPTION
Create an overloaded constructor for VolatileLayerClient.

Create an overloaded constructor for VolatileLayerClient with VolatileLayerClientParams.
Create interface VolatileLayerClientParams with old params.
Mark current constructor as deprecated.
Add new Unit tests for VolatileLayerClient class.
Add new integration tests with VolatileLayerClient new instance.
Update Readme and example files.
Update test coverage.

Resolves: OLPEDGE-1541

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>