### PR TITLE
Create an overloaded constructor for IndexLayerClient.

### DIFF
--- a/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
@@ -35,6 +35,7 @@ describe("IndexLayerClient", () => {
     let getIndexStub: sinon.SinonStub;
     let getBaseUrlRequestStub: sinon.SinonStub;
     let indexLayerClient: dataServiceRead.IndexLayerClient;
+    let indexLayerClientNew: dataServiceRead.IndexLayerClient;
     const mockedHRN = dataServiceRead.HRN.fromString(
         "hrn:here:data:::mocked-hrn"
     );
@@ -50,6 +51,15 @@ describe("IndexLayerClient", () => {
             mockedHRN,
             mockedLayerId,
             (settings as unknown) as dataServiceRead.OlpClientSettings
+        );
+
+        const indexLayerClientParams = {
+            catalogHrn: mockedHRN,
+            layerId: mockedLayerId,
+            settings: (settings as unknown) as dataServiceRead.OlpClientSettings
+        };
+        indexLayerClientNew = new dataServiceRead.IndexLayerClient(
+            indexLayerClientParams
         );
     });
 
@@ -67,7 +77,7 @@ describe("IndexLayerClient", () => {
         sandbox.restore();
     });
 
-    it("Shoud be initialised", async () => {
+    it("Shoud be initialized", async () => {
         assert.isDefined(indexLayerClient);
         expect(indexLayerClient).be.instanceOf(
             dataServiceRead.IndexLayerClient
@@ -336,5 +346,28 @@ describe("IndexLayerClient", () => {
                 expect(err.message).to.be.equal("Test Error");
                 expect(err.name).to.be.equal("HttpError");
             });
+    });
+
+    it("IndexLayerClient instance should be initialized with IndexLayerClientParams", async () => {
+        assert.isDefined(indexLayerClientNew);
+        assert.equal(indexLayerClientNew["hrn"], "hrn:here:data:::mocked-hrn");
+    });
+
+    it("IndexLayerClient should throw Error when setted unsuported parameters", async () => {
+        let settings1 = sandbox.createStubInstance(
+            dataServiceRead.OlpClientSettings
+        );
+
+        assert.throws(
+            () => {
+                new dataServiceRead.IndexLayerClient(
+                    mockedHRN,
+                    "",
+                    (settings1 as unknown) as dataServiceRead.OlpClientSettings
+                );
+            },
+            Error,
+            "Unsupported parameters"
+        );
     });
 });

--- a/docs/examples/nodejs-read-index-layer.md
+++ b/docs/examples/nodejs-read-index-layer.md
@@ -153,13 +153,15 @@ To create the `IndexLayerClient` object:
 2. Create the `OlpClientSettings` object.
    For instructions, see [Create OlpClientSettings](#create-olpclientsettings).
 
-3. Create the `IndexLayerClient` object with the HERE Resource Name (HRN) of the catalog that contains the layer, the layer ID, and the OLP client settings from step 2.
+3. Create the `IndexLayerClient` object IndexLayerClientParams that contains the HERE Resource Name (HRN) of the catalog, the layer ID, and the OLP client settings from step 2.
 
    ```typescript
-   const indexLayerClient = await new IndexLayerClient()
-       hrn: "CatalogHRN",
-       layerId: "LayerId",
-       olpClientSettings
+   const indexLayerClient = await new IndexLayerClient(
+      {
+         catalogHrn: "CatalogHRN",
+         layerId: "LayerId",
+         settings: olpClientSettings
+      }
    );
    ```
 

--- a/tests/integration/IndexLayerClient.test.ts
+++ b/tests/integration/IndexLayerClient.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ describe("IndexLayerClient", () => {
     fetchStub.callsFake(fetchMock.fetch());
   });
 
-  it("Shoud be initialised with settings", async () => {
+  it("Shoud be initialized with settings", async () => {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -221,5 +221,23 @@ describe("IndexLayerClient", () => {
 
     assert.isDefined(data);
     expect(fetchStub.callCount).to.be.equal(2);
+  });
+
+  it("Shoud be initialized with IndexLayerClientParams", async () => {
+    const settings = new OlpClientSettings({
+      environment: "here",
+      getToken: () => Promise.resolve("test-token-string")
+    });
+
+    const indexLayerClientParams = {
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: settings
+    };
+    const indexLayerClient = new IndexLayerClient(indexLayerClientParams);
+
+    assert.isDefined(indexLayerClient);
+    expect(indexLayerClient).to.be.instanceOf(IndexLayerClient);
+    assert.equal(indexLayerClient["hrn"], "hrn:here:data:::test-hrn");
   });
 });


### PR DESCRIPTION
Create an overloaded constructor for IndexLayerClient.

Create an overloaded constructor for IndexLayerClient with IndexLayerClientParams.
Create interface IndexLayerClientParams with old params.
Mark current constructor as deprecated.
Add new Unit tests for IndexLayerClient class.
Add new integration tests with IndexLayerClient new instance.
Update IndexLayerClient example file.
Update test coverage.

Resolves: OLPEDGE-1542

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>