### PR TITLE
Add Poll method to the StreamLayerClient

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/stream-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/stream-api.ts
@@ -240,7 +240,7 @@ export async function consumeData(
         mode?: "serial" | "parallel";
         xCorrelationId?: string;
     }
-): Promise<ConsumeDataResponse> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/partitions".replace(
         "{layerId}",
         UrlBuilder.toString(params["layerId"])
@@ -259,7 +259,7 @@ export async function consumeData(
         headers["X-Correlation-Id"] = params["xCorrelationId"] as string;
     }
 
-    return builder.request<ConsumeDataResponse>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -434,7 +434,7 @@ export async function subscribe(
         consumerId?: string;
         subscriptionProperties?: ConsumerProperties;
     }
-): Promise<ConsumerSubscribeResponse> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/subscribe".replace(
         "{layerId}",
         UrlBuilder.toString(params["layerId"])
@@ -457,5 +457,5 @@ export async function subscribe(
         });
     }
 
-    return builder.request<ConsumerSubscribeResponse>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }

--- a/@here/olp-sdk-dataservice-api/test/StreamApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/StreamApi.test.ts
@@ -57,16 +57,16 @@ describe("StreamApi", () => {
     });
 
     it("Should subscribe works as expected", async () => {
-        const builder = {
+        const builder = ({
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-id/subscribe?mode=parallel&subscriptionId=testSubsId&consumerId=testConsumerId"
                 );
                 expect(options.method).to.be.equal("POST");
                 return Promise.resolve();
             }
-        } as RequestBuilder;
+        } as unknown) as RequestBuilder;
 
         await StreamApi.subscribe(builder, {
             layerId: "mocked-id",
@@ -81,16 +81,16 @@ describe("StreamApi", () => {
     });
 
     it("Should consumeData works as expected", async () => {
-        const builder = {
+        const builder = ({
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-id/partitions?subscriptionId=testSubsId&mode=parallel"
                 );
                 expect(options.method).to.be.equal("GET");
                 return Promise.resolve();
             }
-        } as RequestBuilder;
+        } as unknown) as RequestBuilder;
 
         await StreamApi.consumeData(builder, {
             layerId: "mocked-id",

--- a/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
@@ -23,7 +23,6 @@ import sinonChai = require("sinon-chai");
 
 import * as dataServiceRead from "../../lib";
 import { StreamApi } from "@here/olp-sdk-dataservice-api";
-import { SubscribeRequest } from "../../lib";
 
 chai.use(sinonChai);
 
@@ -34,6 +33,8 @@ describe("StreamLayerClient", () => {
     let sandbox: sinon.SinonSandbox;
     let getBaseUrlRequestStub: sinon.SinonStub;
     let subscribeStub: sinon.SinonStub;
+    let pollStub: sinon.SinonStub;
+    let commitOffsetsStub: sinon.SinonStub;
     let streamLayerClient: dataServiceRead.StreamLayerClient;
     const mockedHRN = dataServiceRead.HRN.fromString(
         "hrn:here:data:::mocked-hrn"
@@ -56,6 +57,8 @@ describe("StreamLayerClient", () => {
 
     beforeEach(() => {
         subscribeStub = sandbox.stub(StreamApi, "subscribe");
+        pollStub = sandbox.stub(StreamApi, "consumeData");
+        commitOffsetsStub = sandbox.stub(StreamApi, "commitOffsets");
         getBaseUrlRequestStub = sandbox.stub(
             dataServiceRead.RequestFactory,
             "getBaseUrl"
@@ -79,10 +82,15 @@ describe("StreamLayerClient", () => {
         );
     });
 
-    it("Should subscribe method post data and return url and id", async () => {
+    it("Should subscribe method post data and return subscription id", async () => {
+        const headers = new Headers();
+        headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-b5ff");
         const mockResponse = {
-            nodeBaseURL: "https://mock-url/hrn/id",
-            subscriptionId: "-9141392.f96875c-9422-4df4-b5ff-41a4f459"
+            headers,
+            subscriptionId: "-9141392.f96875c-9422-4df4-b5ff-41a4f459",
+            json: function() {
+                return this.subscriptionId;
+            }
         };
         subscribeStub.callsFake(
             (
@@ -93,17 +101,14 @@ describe("StreamLayerClient", () => {
             }
         );
 
-        const request = new SubscribeRequest();
+        const request = new dataServiceRead.SubscribeRequest();
         const subscription = await streamLayerClient.subscribe(request);
 
         assert.isDefined(subscription);
-        expect(subscription.nodeBaseURL).to.be.equal(mockResponse.nodeBaseURL);
-        expect(subscription.subscriptionId).to.be.equal(
-            mockResponse.subscriptionId
-        );
+        expect(subscription).to.be.equal(mockResponse.subscriptionId);
     });
 
-    it("Should be aborted fetching by abort signal", async () => {
+    it("Should subscribe be aborted fetching by abort signal", async () => {
         const mockResponse = {
             nodeBaseURL: "https://mock-url/hrn/id",
             subscriptionId: "-9141392.f96875c-9422-4df4-b5ff-41a4f459"
@@ -120,7 +125,7 @@ describe("StreamLayerClient", () => {
             }
         );
 
-        const request = new SubscribeRequest();
+        const request = new dataServiceRead.SubscribeRequest();
         const abortController = new AbortController();
 
         streamLayerClient
@@ -137,9 +142,9 @@ describe("StreamLayerClient", () => {
         abortController.abort();
     });
 
-    it("Should baseUrl error be handled", async () => {
+    it("Should baseUrl error be handled in the subscribe method", async () => {
         const mockedErrorResponse = "Bad response";
-        const request = new SubscribeRequest();
+        const request = new dataServiceRead.SubscribeRequest();
 
         getBaseUrlRequestStub.callsFake(() =>
             Promise.reject({
@@ -154,5 +159,117 @@ describe("StreamLayerClient", () => {
                 assert.isDefined(error);
                 assert.equal(mockedErrorResponse, error.statusText);
             });
+    });
+
+    it("Should poll method get data, post offsets and return messages", async () => {
+        const headers = new Headers();
+        const commitOffsetsResponse = ("Ok" as unknown) as Response;
+        headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-bdfj");
+        const mockResponse = ({
+            headers,
+            json: () => {
+                return {
+                    messages: [
+                        {
+                            metaData: {
+                                partition: "314010583",
+                                checksum: "ff7494d6f17da702862e550c907c0a91",
+                                compressedDataSize: 152417,
+                                dataSize: 100500,
+                                data: "",
+                                dataHandle:
+                                    "iVBORw0-Lf9HdIZBfNEiKAA-AAAE-lFTkSuQmCC",
+                                timestamp: 1517916706
+                            },
+                            offset: {
+                                partition: 7,
+                                offset: 38562
+                            }
+                        },
+                        {
+                            metaData: {
+                                partition: "314010584",
+                                checksum: "ff7494d6f17da702862e550c907c0a91",
+                                dataSize: 100500,
+                                data:
+                                    "7n348c7y49nry394y39yv39y384tvn3984tvn34ty034ynt3yvt983ny",
+                                dataHandle: "",
+                                timestamp: 1517916707
+                            },
+                            offset: {
+                                partition: 8,
+                                offset: 38563
+                            }
+                        }
+                    ]
+                };
+            }
+        } as unknown) as Response;
+        pollStub.callsFake(
+            (builder: any, params: any): Promise<Response> => {
+                return Promise.resolve(mockResponse);
+            }
+        );
+
+        commitOffsetsStub.callsFake(
+            (builder: any, params: any): Promise<Response> => {
+                return Promise.resolve(commitOffsetsResponse);
+            }
+        );
+
+        const request = new dataServiceRead.PollRequest();
+        const messages = await streamLayerClient.poll(request);
+
+        assert.isDefined(messages);
+        expect(messages.length).to.be.equal(2);
+        expect(messages[0].metaData.dataSize).to.be.equal(100500);
+    });
+
+    it("Should poll be aborted fetching by abort signal", async () => {
+        const mockResponse = ({
+            metaData: {},
+            offset: {}
+        } as unknown) as Response;
+
+        pollStub.callsFake(
+            (builder: any, params: any): Promise<Response> => {
+                return builder.abortSignal.aborted
+                    ? Promise.reject("AbortError")
+                    : Promise.resolve(mockResponse);
+            }
+        );
+
+        const request = new dataServiceRead.PollRequest();
+        const abortController = new AbortController();
+
+        streamLayerClient
+            .poll(
+                (request as unknown) as dataServiceRead.PollRequest,
+                abortController.signal
+            )
+            .then()
+            .catch((err: any) => {
+                assert.strictEqual(err, "AbortError");
+                assert.isTrue(abortController.signal.aborted);
+            });
+
+        abortController.abort();
+    });
+
+    it("Should baseUrl error be handled in the poll method", async () => {
+        const mockedErrorResponse = "Bad response";
+        const request = new dataServiceRead.PollRequest();
+
+        getBaseUrlRequestStub.callsFake(() =>
+            Promise.reject({
+                status: 400,
+                statusText: "Bad response"
+            })
+        );
+
+        const messages = await streamLayerClient.poll(request).catch(error => {
+            assert.isDefined(error);
+            assert.equal(mockedErrorResponse, error.statusText);
+        });
     });
 });


### PR DESCRIPTION
Poll method allows user to consume data from stream layer. Returns messages from a stream layer formatted similar to a Partition object.
If the data size is less than 1 MB, the data field will be populated. Otherwise the data handle will be returned pointing to the object in the Blob store.

* Add Poll method to the StreamLayerClient
* Add unit tests
* Add support for X-Correlation-Id

Resolves: OLPEDGE-1527, OLPEDGE-1523
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>