### PR TITLE
Request as not required for the method getCatalogs

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/ConfigClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/ConfigClient.ts
@@ -44,22 +44,29 @@ export class ConfigClient {
      * If the schema is not set, the filter returns all of the catalogs to which you have access.
      */
     public async getCatalogs(
-        request: CatalogsRequest
+        request?: CatalogsRequest
     ): Promise<ConfigApi.CatalogsListResult> {
         const requestBuilder = await RequestFactory.create(
             "config",
             this.apiVersion,
             this.settings
         ).catch(error => Promise.reject(error));
-        return ConfigApi.getCatalogs(
-            requestBuilder,
-            request.getSchema()
-                ? {
-                      verbose: "true",
-                      schemaHrn: request.getSchema(),
-                      billingTag: request.getBillingTag()
-                  }
-                : { billingTag: request.getBillingTag() }
-        );
+
+        const params: {
+            verbose?: string;
+            schemaHrn?: string;
+            billingTag?: string;
+        } = {};
+
+        if (request) {
+            params.billingTag = request.getBillingTag();
+
+            if (request.getSchema()) {
+                params.verbose = "true";
+                params.schemaHrn = request.getSchema();
+            }
+        }
+
+        return ConfigApi.getCatalogs(requestBuilder, params);
     }
 }


### PR DESCRIPTION
Make request as not required for the method ConfigClient.getCatalogs.
Also, the tests for the method have been refactored.

Resolves: OLPEDGE-1553

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>