### PR TITLE
Add Seek method to the StreamLayerClient

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/stream-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/stream-api.ts
@@ -404,7 +404,7 @@ export async function seekToOffset(
         headers["X-Correlation-Id"] = params["xCorrelationId"] as string;
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**

--- a/@here/olp-sdk-dataservice-api/test/StreamApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/StreamApi.test.ts
@@ -101,16 +101,16 @@ describe("StreamApi", () => {
     });
 
     it("Should seekToOffset works as expected", async () => {
-        const builder = {
+        const builder = ({
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-id/seek?subscriptionId=testSubsId&mode=parallel"
                 );
                 expect(options.method).to.be.equal("PUT");
                 return Promise.resolve();
             }
-        } as RequestBuilder;
+        } as unknown) as RequestBuilder;
 
         await StreamApi.seekToOffset(builder, {
             layerId: "mocked-id",

--- a/@here/olp-sdk-dataservice-read/lib/client/SeekRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SeekRequest.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { StreamApi } from "@here/olp-sdk-dataservice-api";
+
+/**
+ * Prepares information for calls to the OLP Stream Service.
+ */
+export class SeekRequest {
+    private mode?: "serial" | "parallel";
+    private subscriptionId?: string;
+    private offsets?: StreamApi.SeekOffsetsRequest;
+
+    /**
+     * Gets the subscription mode for the request.
+     *
+     * @return The subscription mode.
+     */
+    public getMode(): "serial" | "parallel" | undefined {
+        return this.mode;
+    }
+
+    /**
+     * A setter for the provided subscription mode.
+     *
+     * @param mode The subscription mode.
+     * @returns The [[SeekRequest]] instance that you can use to chain methods.
+     */
+    public withMode(mode: "serial" | "parallel"): SeekRequest {
+        this.mode = mode;
+        return this;
+    }
+
+    /**
+     * Gets the subscription id for the request.
+     *
+     * @return The subscription id.
+     */
+    public getSubscriptionId(): string | undefined {
+        return this.subscriptionId;
+    }
+
+    /**
+     * A setter for the provided subscription id.
+     *
+     * @param id The subscription id.
+     * @returns The [[SeekRequest]] instance that you can use to chain methods.
+     */
+    public withSubscriptionId(id: string): SeekRequest {
+        this.subscriptionId = id;
+        return this;
+    }
+
+    public withSeekOffsets(offsets: StreamApi.SeekOffsetsRequest): SeekRequest {
+        this.offsets = offsets;
+        return this;
+    }
+
+    public getSeekOffsets(): StreamApi.SeekOffsetsRequest | undefined {
+        return this.offsets;
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/client/index.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/index.ts
@@ -43,3 +43,4 @@ export * from "./StreamLayerClient";
 export * from "./SubscribeRequest";
 export * from "./PollRequest";
 export * from "./UnsubscribeRequest";
+export * from "./SeekRequest";

--- a/@here/olp-sdk-dataservice-read/test/unit/SeekRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SeekRequest.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { SeekRequest } from "../../lib";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("SubscribeRequest", () => {
+    it("Should initialize", () => {
+        const seekRequest = new SeekRequest();
+
+        assert.isDefined(seekRequest);
+        expect(seekRequest).be.instanceOf(SeekRequest);
+    });
+
+    it("Should set parameters", () => {
+        const mockMode = "parallel";
+        const mockSubId = "1111111111";
+        const mockOffsets = {
+            offsets: [
+                {
+                    partition: 1,
+                    offset: 1
+                },
+                {
+                    partition: 2,
+                    offset: 2
+                }
+            ]
+        };
+
+        const seekRequest = new SeekRequest();
+        const seekRequestWithMode = seekRequest.withMode(mockMode);
+        const seekRequestWithSub = seekRequest.withSubscriptionId(mockSubId);
+        const seekRequestWithOffsets = seekRequest.withSeekOffsets(mockOffsets);
+
+        expect(seekRequestWithMode.getMode()).to.be.equal(mockMode);
+        expect(seekRequestWithSub.getSubscriptionId()).to.be.equal(mockSubId);
+        expect(seekRequestWithOffsets.getSeekOffsets()).to.be.equal(
+            mockOffsets
+        );
+    });
+
+    it("Should get parameters with chain", () => {
+        const mockMode = "parallel";
+        const mockSubId = "1111111111";
+        const mockOffsets = {
+            offsets: [
+                {
+                    partition: 1,
+                    offset: 1
+                },
+                {
+                    partition: 2,
+                    offset: 2
+                }
+            ]
+        };
+
+        const seekRequest = new SeekRequest()
+            .withMode(mockMode)
+            .withSubscriptionId(mockSubId)
+            .withSeekOffsets(mockOffsets);
+
+        expect(seekRequest.getMode()).to.be.equal(mockMode);
+        expect(seekRequest.getSubscriptionId()).to.be.equal(mockSubId);
+        expect(seekRequest.getSeekOffsets()).to.be.equal(mockOffsets);
+    });
+});


### PR DESCRIPTION
Seek method allows to start reading data from a specified offset. The message pointer can be moved to any offset in the layer.

* Add SeekRequest
* Add unit tests to the SeekRequest
* Add Seek method to the StreamLayerClient
* Add unit tests to mentioned method

Resolves: OLPEDGE-1525
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>