### PR TITLE
Add Unit Tests for versioned layer client with version 0 in constructor.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
@@ -30,7 +30,7 @@ export class PartitionsRequest {
     private additionalFields?: AdditionalFields;
 
     /**
-     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * This method is deprecated and is not used. If you need to set the version, then
      * initialize the version client with not deprecated constructor, in other case the latest version will be used.
      *
      * Gets a layer version for the request.
@@ -42,7 +42,7 @@ export class PartitionsRequest {
     }
 
     /**
-     * @deprecated This method is deprecated and is not used. If you need to set the version, then
+     * This method is deprecated and is not used. If you need to set the version, then
      * initialize the version client with not deprecated constructor, in other case the latest version will be used.
      *
      * An optional method that sets the provided layer version.

--- a/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
@@ -181,7 +181,7 @@ export class QueryClient {
         return QueryApi.getPartitionsById(requestBuilder, {
             layerId,
             partition: idsList,
-            version: version ? `${version}` : undefined
+            version: version !== undefined ? `${version}` : undefined
         });
     }
 

--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -158,9 +158,9 @@ export class VersionedLayerClient {
             }
 
             if (quadKey) {
-                const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest()
-                    .withQuadKey(quadKey)
-                    .withVersion(this.version);
+                const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest().withQuadKey(
+                    quadKey
+                );
                 const quadTreeIndexResponse = await this.getPartitions(
                     quadKeyPartitionsRequest
                 ).catch(error => Promise.reject(error));
@@ -269,6 +269,7 @@ export class VersionedLayerClient {
         if (request.getPartitionIds()) {
             const queryClient = new QueryClient(this.settings);
 
+            request.withVersion(this.version);
             return queryClient.getPartitionsById(
                 request,
                 this.layerId,

--- a/tests/integration/VersionedLayerClient.test.ts
+++ b/tests/integration/VersionedLayerClient.test.ts
@@ -149,7 +149,7 @@ describe("VersionedLayerClient", () => {
 
     // Set the response with mocked partitions for IDs 100 and 1000 from Query service
     mockedResponses.set(
-      `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/partitions?partition=100&partition=1000`,
+      `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/partitions?partition=100&partition=1000&version=128`,
       new Response(
         JSON.stringify({
           partitions: [


### PR DESCRIPTION
Add Unit Tests for versioned layer client with version 0 in constructor.
Remove deprecation for methods getversion and withVersion of PartitionsRequest.
Fix bug for method getPartitions.
Update coverage for VersionLayerClient class.

Resolves: OLPEDGE-1617

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>