### PR TITLE
Fix NPM publish on condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: bionic
 language: node_js
 node_js:
   - lts/*
@@ -14,12 +14,13 @@ addons:
 branches:
     only:
       - master
+script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh && echo "Event $TRAVIS_EVENT_TYPE, Message $TRAVIS_COMMIT_MESSAGE"
 name: "PSV Linux Build & Test"
-script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh
+
 deploy:
   - provider: script
-    script: $WORKSPACE/scripts/publish-packages.sh
+    script: $WORKSPACE/scripts/publish-packages.sh && echo "Event $TRAVIS_EVENT_TYPE, Message $TRAVIS_COMMIT_MESSAGE"
     cleanup: false
     on:
        branch: master
-       condition: "$TRAVIS_TAG =~ ^v[0-9].[0-9].[0-9]$"
+       condition: (($TRAVIS_EVENT_TYPE = api) AND ($TRAVIS_COMMIT_MESSAGE = "Publish to NPM"))


### PR DESCRIPTION
Add condition for event type api, means we publish only
when job started from UI via Trigger Build.
Travis Variable details there:
https://docs.travis-ci.com/user/environment-variables/#default-environment-variables

Relates-to : OLPEDGE-1539

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>