### PR TITLE
Update LookupAPI requests

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/lookup-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/lookup-api.ts
@@ -66,7 +66,7 @@ export interface ApiNotFoundError {
     /**
      * Complete details of the error
      */
-    detail?: Array<{name: string, error: string}>;
+    detail?: Array<{ name: string; error: string }>;
     error?: string;
     error_description?: string;
 }
@@ -102,11 +102,14 @@ export async function platformAPI(
 }
 
 /**
+ * @deprecated This method is deprecated and is not used. Please used getPlatformAPIList()
  * Return the list of the platform APIs. This response is valid for the time specified by 'Cache-Control' header.
  *
  * @summary Return the list of the platform APIs.
  */
-export async function platformAPIList(builder: RequestBuilder): Promise<API[] | ApiNotFoundError> {
+export async function platformAPIList(
+    builder: RequestBuilder
+): Promise<API[] | ApiNotFoundError> {
     const baseUrl = "/platform/apis";
 
     const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
@@ -118,6 +121,27 @@ export async function platformAPIList(builder: RequestBuilder): Promise<API[] | 
     };
 
     return builder.request<API[]>(urlBuilder, options);
+}
+
+/**
+ * Return the list of the platform APIs. This response is valid for the time specified by 'Cache-Control' header.
+ *
+ * @summary Return the list of the platform APIs.
+ */
+export async function getPlatformAPIList(
+    builder: RequestBuilder
+): Promise<Response> {
+    const baseUrl = "/platform/apis";
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "GET",
+        headers
+    };
+
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /* ===================================================================
@@ -156,6 +180,7 @@ export async function resourceAPI(
 }
 
 /**
+ * @deprecated This method is deprecated and is not used. Please used getResourceAPIList()
  * Return the list of APIs for a given resource identified by hrn. This response is valid for the time specified by 'Cache-Control' header.
  *
  * @summary Return the list of APIs for a given resource.
@@ -181,4 +206,32 @@ export async function resourceAPIList(
     };
 
     return builder.request<API[]>(urlBuilder, options);
+}
+
+/**
+ * Return the list of APIs for a given resource identified by hrn. This response is valid for the time specified by 'Cache-Control' header.
+ *
+ * @summary Return the list of APIs for a given resource.
+ * @param hrn The HRN identifying the resource
+ * @param region If you want to look up a specific region for a given resource.
+ */
+export async function getResourceAPIList(
+    builder: RequestBuilder,
+    params: { hrn: string; region?: string }
+): Promise<Response> {
+    const baseUrl = "/resources/{hrn}/apis".replace(
+        "{hrn}",
+        UrlBuilder.toString(params["hrn"])
+    );
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+    urlBuilder.appendQuery("region", params["region"]);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "GET",
+        headers
+    };
+
+    return builder.requestBlob(urlBuilder, options);
 }

--- a/@here/olp-sdk-dataservice-read/lib/cache/ApiCacheRepository.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/ApiCacheRepository.ts
@@ -38,6 +38,11 @@ export type ApiName =
     | "volatile-blob";
 
 /**
+ * The list of the types could be saved in the cache.
+ */
+export type CacheType = "api" | "age";
+
+/**
  * Caches the base URLs of the API using a key-value pair.
  * The key format is `<hrn>::<service_name>::<serviceVersion>::api`.
  */
@@ -46,7 +51,7 @@ export class ApiCacheRepository {
 
     /**
      * Generates the [[ApiCacheRepository]] instance.
-     * 
+     *
      * @param cache The [[KeyValueCache]] instance.
      * @param hrn The HERE Resource Name (HRN) for which you want to use the [[ApiCacheRepository]] instance.
      * @return The [[ApiCacheRepository]] instance.
@@ -57,7 +62,7 @@ export class ApiCacheRepository {
 
     /**
      * Stores a key-value pair in the cache.
-     * 
+     *
      * @param service The name of the API service for which you need the key-value pair.
      * @param serviceVersion The version of the service.
      * @param serviceUrl The base URL of the service.
@@ -66,29 +71,35 @@ export class ApiCacheRepository {
     public put(
         service: ApiName,
         serviceVersion: string,
-        serviceUrl: string
+        serviceUrl: string,
+        type: CacheType
     ): boolean {
-        const key = this.createKey(this.hrn, service, serviceVersion);
+        const key = this.createKey(this.hrn, service, serviceVersion, type);
         return this.cache.put(key, serviceUrl);
     }
 
     /**
      * Gets a base URL from the cache.
-     * 
+     *
      * @param service The name of the API service for which you want to get the base URL.
      * @param serviceVersion The service version.
      * @return The base URL of the service, or undefined if the base URL does not exist.
      */
-    public get(service: string, serviceVersion: string): string | undefined {
-        const key = this.createKey(this.hrn, service, serviceVersion);
+    public get(
+        service: string,
+        serviceVersion: string,
+        type: CacheType
+    ): string | undefined {
+        const key = this.createKey(this.hrn, service, serviceVersion, type);
         return this.cache.get(key);
     }
 
     private createKey(
         hrn: string,
         service: string,
-        serviceVersion: string
+        serviceVersion: string,
+        type: CacheType
     ): string {
-        return hrn + "::" + service + "::" + serviceVersion + "::api";
+        return `${hrn}::${service}::${serviceVersion}::${type}`;
     }
 }

--- a/@here/olp-sdk-dataservice-read/test/unit/ApiCacheRepository.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ApiCacheRepository.test.ts
@@ -56,12 +56,17 @@ describe("ApiCacheRepository", () => {
         const operationIsSuccessful = apiCacheRepository.put(
             testServiceApiName,
             testServiceVersion,
-            testServiceUrl
+            testServiceUrl,
+            "api"
         );
 
         expect(operationIsSuccessful).equal(true);
         expect(
-            apiCacheRepository.get(testServiceApiName, testServiceVersion)
+            apiCacheRepository.get(
+                testServiceApiName,
+                testServiceVersion,
+                "api"
+            )
         ).equal(testServiceUrl);
     });
 
@@ -69,22 +74,36 @@ describe("ApiCacheRepository", () => {
         apiCacheRepository.put(
             testServiceApiName2,
             testServiceVersion2,
-            testServiceUrl2
+            testServiceUrl2,
+            "api"
         );
         apiCacheRepository.put(
             testServiceApiName3,
             testServiceVersion3,
-            testServiceUrl3
+            testServiceUrl3,
+            "api"
         );
 
         expect(
-            apiCacheRepository.get(testServiceApiName, testServiceVersion)
+            apiCacheRepository.get(
+                testServiceApiName,
+                testServiceVersion,
+                "api"
+            )
         ).equal(testServiceUrl);
         expect(
-            apiCacheRepository.get(testServiceApiName2, testServiceVersion2)
+            apiCacheRepository.get(
+                testServiceApiName2,
+                testServiceVersion2,
+                "api"
+            )
         ).equal(testServiceUrl2);
         expect(
-            apiCacheRepository.get(testServiceApiName3, testServiceVersion3)
+            apiCacheRepository.get(
+                testServiceApiName3,
+                testServiceVersion3,
+                "api"
+            )
         ).equal(testServiceUrl3);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
@@ -69,16 +69,17 @@ class MockedApiCacheRepository {
         this.hrn = hrn ? hrn.toString() : "plathorm-api";
     }
 
-    public get(service: string, serviceVersion: string) {
-        return this.cache.get(`${service}-${serviceVersion}`);
+    public get(service: string, serviceVersion: string, type: string) {
+        return this.cache.get(`${service}-${serviceVersion}-${type}`);
     }
 
     public put(
         serviceName: string,
         serviceVersion: string,
-        baseURL: string
+        baseURL: string,
+        type: string
     ): boolean {
-        this.cache.set(`${serviceName}-${serviceVersion}`, baseURL);
+        this.cache.set(`${serviceName}-${serviceVersion}-${type}`, baseURL);
         return true;
     }
 }
@@ -129,17 +130,26 @@ describe("RequestFactory", () => {
 
     describe("create()", () => {
         it("Should return created RequestBuilder with correct base url for platform service", async () => {
+            const headers = new Headers();
+            headers.append("cache-control", "max-age=3600");
+            const response = {
+                headers,
+                resp: [
+                    {
+                        api: "statistics",
+                        version: "v1",
+                        baseURL:
+                            "test-base-url-to-platform-service-for-request-builder"
+                    }
+                ],
+                json: function() {
+                    return this.resp;
+                }
+            };
             sandbox
-                .stub(dataServiceApi.LookupApi, "platformAPIList")
+                .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
                 .callsFake(() =>
-                    Promise.resolve([
-                        {
-                            api: "statistics",
-                            version: "v1",
-                            baseURL:
-                                "test-base-url-to-platform-service-for-request-builder"
-                        }
-                    ])
+                    Promise.resolve((response as unknown) as Response)
                 );
 
             const settings = new MockedOlpClientSettings();
@@ -155,13 +165,18 @@ describe("RequestFactory", () => {
         });
 
         it("Should reject with correct error about base url", async () => {
-            sandbox.stub(dataServiceApi.LookupApi, "platformAPIList").callsFake(
-                () =>
-                    Promise.resolve({
-                        status: 204,
-                        title: "No content"
-                    }) as any
-            );
+            sandbox
+                .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
+                .callsFake(
+                    () =>
+                        Promise.resolve({
+                            status: 204,
+                            title: "No content",
+                            json: function() {
+                                return this;
+                            }
+                        }) as any
+                );
 
             const settings = new MockedOlpClientSettings();
 
@@ -179,16 +194,25 @@ describe("RequestFactory", () => {
 
     describe("getBaseUrl()", () => {
         it("Should return correct base url for platform service", async () => {
+            const headers = new Headers();
+            headers.append("cache-control", "max-age=3600");
+            const response = {
+                headers,
+                resp: [
+                    {
+                        api: "statistics",
+                        version: "v1",
+                        baseURL: "test-base-url-to-platform-service"
+                    }
+                ],
+                json: function() {
+                    return this.resp;
+                }
+            };
             sandbox
-                .stub(dataServiceApi.LookupApi, "platformAPIList")
+                .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
                 .callsFake(() =>
-                    Promise.resolve([
-                        {
-                            api: "statistics",
-                            version: "v1",
-                            baseURL: "test-base-url-to-platform-service"
-                        }
-                    ])
+                    Promise.resolve((response as unknown) as Response)
                 );
             const settings = new MockedOlpClientSettings();
             const baseUrl = await dataServiceRead.RequestFactory.getBaseUrl(
@@ -200,16 +224,25 @@ describe("RequestFactory", () => {
         });
 
         it("Should return correct base url for resource service", async () => {
+            const headers = new Headers();
+            headers.append("cache-control", "max-age=3600");
+            const response = {
+                headers,
+                resp: [
+                    {
+                        api: "statistics",
+                        version: "v1",
+                        baseURL: "test-base-url-to-resource-service"
+                    }
+                ],
+                json: function() {
+                    return this.resp;
+                }
+            };
             sandbox
-                .stub(dataServiceApi.LookupApi, "resourceAPIList")
+                .stub(dataServiceApi.LookupApi, "getResourceAPIList")
                 .callsFake(() =>
-                    Promise.resolve([
-                        {
-                            api: "statistics",
-                            version: "v1",
-                            baseURL: "test-base-url-to-resource-service"
-                        }
-                    ])
+                    Promise.resolve((response as unknown) as Response)
                 );
             const settings = new MockedOlpClientSettings();
 
@@ -228,13 +261,16 @@ describe("RequestFactory", () => {
 
         it("Should reject with correct error message", async () => {
             sandbox
-                .stub(dataServiceApi.LookupApi, "platformAPIList")
+                .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
                 .callsFake(() =>
-                    Promise.resolve({
+                    Promise.resolve(({
                         status: 404,
                         title: "Service Not Found",
-                        detail: []
-                    })
+                        detail: [],
+                        json: function() {
+                            return this;
+                        }
+                    } as unknown) as Response)
                 );
             const settings = new MockedOlpClientSettings();
             try {
@@ -250,8 +286,14 @@ describe("RequestFactory", () => {
 
         it("Should reject with correct custom error message", async () => {
             sandbox
-                .stub(dataServiceApi.LookupApi, "platformAPIList")
-                .callsFake(() => Promise.resolve({}));
+                .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
+                .callsFake(() =>
+                    Promise.resolve(({
+                        json: function() {
+                            return this;
+                        }
+                    } as unknown) as Response)
+                );
             const settings = new MockedOlpClientSettings();
             try {
                 await dataServiceRead.RequestFactory.getBaseUrl(
@@ -265,16 +307,25 @@ describe("RequestFactory", () => {
         });
 
         it("Should reject with not found error message", async () => {
+            const headers = new Headers();
+            headers.append("cache-control", "max-age=3600");
+            const response = {
+                headers,
+                resp: [
+                    {
+                        api: "metadata",
+                        version: "v1",
+                        baseURL: "test-base-url-to-platform-service"
+                    }
+                ],
+                json: function() {
+                    return this.resp;
+                }
+            };
             sandbox
-                .stub(dataServiceApi.LookupApi, "platformAPIList")
+                .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
                 .callsFake(() =>
-                    Promise.resolve([
-                        {
-                            api: "metadata",
-                            version: "v1",
-                            baseURL: "test-base-url-to-platform-service"
-                        }
-                    ])
+                    Promise.resolve((response as unknown) as Response)
                 );
             const settings = new MockedOlpClientSettings();
             try {
@@ -289,16 +340,25 @@ describe("RequestFactory", () => {
         });
 
         it("Should reject with not found error message for hrn", async () => {
+            const headers = new Headers();
+            headers.append("cache-control", "max-age=3600");
+            const response = {
+                headers,
+                resp: [
+                    {
+                        api: "metadata",
+                        version: "v1",
+                        baseURL: "test-base-url-to-platform-service"
+                    }
+                ],
+                json: function() {
+                    return this.resp;
+                }
+            };
             sandbox
-                .stub(dataServiceApi.LookupApi, "resourceAPIList")
+                .stub(dataServiceApi.LookupApi, "getResourceAPIList")
                 .callsFake(() =>
-                    Promise.resolve([
-                        {
-                            api: "metadata",
-                            version: "v1",
-                            baseURL: "test-base-url-to-platform-service"
-                        }
-                    ])
+                    Promise.resolve((response as unknown) as Response)
                 );
             const settings = new MockedOlpClientSettings();
             try {
@@ -320,19 +380,37 @@ describe("RequestFactory", () => {
             }
         });
 
-        it("Should return correct base url for resource service from cache", async () => {
+        it("Should return correct base url for resource service from cache while max-age is valid", async () => {
+            const headers = new Headers();
+            headers.append("cache-control", "max-age=2");
+            const response = {
+                headers,
+                resp: [
+                    {
+                        api: "statistics",
+                        version: "v1",
+                        baseURL: "test-base-url-to-resource-service"
+                    }
+                ],
+                json: function() {
+                    return this.resp;
+                }
+            };
             const resourceApiStub = sandbox.stub(
                 dataServiceApi.LookupApi,
-                "resourceAPIList"
+                "getResourceAPIList"
             );
-            const platformApiStub = sandbox.stub(
-                dataServiceApi.LookupApi,
-                "platformAPIList"
+
+            resourceApiStub.callsFake(() =>
+                Promise.resolve((response as unknown) as Response)
             );
             const settings = new MockedOlpClientSettings();
-            settings.cache.set("statistics-v1", "test-cached-service-url");
+            const platformApiStub = sandbox.stub(
+                dataServiceApi.LookupApi,
+                "getPlatformAPIList"
+            );
 
-            const baseUrl = await dataServiceRead.RequestFactory.getBaseUrl(
+            const baseUrl1 = await dataServiceRead.RequestFactory.getBaseUrl(
                 "statistics",
                 "v1",
                 settings as any,
@@ -342,9 +420,40 @@ describe("RequestFactory", () => {
                     service: "here-test-service"
                 }) as any
             );
-            expect(baseUrl).to.be.equal("test-cached-service-url");
-            expect(resourceApiStub.callCount).to.be.equal(0);
-            expect(platformApiStub.callCount).to.be.equal(0);
+            expect(resourceApiStub.callCount).to.be.equal(1);
+            expect(baseUrl1).to.be.equal("test-base-url-to-resource-service");
+
+            const baseUrl2 = await dataServiceRead.RequestFactory.getBaseUrl(
+                "statistics",
+                "v1",
+                settings as any,
+                new MockedHrn({
+                    partition: "here-dev",
+                    resource: "here-test-resource",
+                    service: "here-test-service"
+                }) as any
+            );
+
+            expect(resourceApiStub.callCount).to.be.equal(1);
+            expect(baseUrl2).to.be.equal("test-base-url-to-resource-service");
+
+            setTimeout(async () => {
+                const baseUrl3 = await dataServiceRead.RequestFactory.getBaseUrl(
+                    "statistics",
+                    "v1",
+                    settings as any,
+                    new MockedHrn({
+                        partition: "here-dev",
+                        resource: "here-test-resource",
+                        service: "here-test-service"
+                    }) as any
+                );
+
+                expect(resourceApiStub.callCount).to.be.equal(2);
+                expect(baseUrl3).to.be.equal(
+                    "test-base-url-to-resource-service"
+                );
+            }, 3000);
         });
     });
 });

--- a/tests/integration/ArtifactClient.test.ts
+++ b/tests/integration/ArtifactClient.test.ts
@@ -69,6 +69,8 @@ describe("ArtifactClient", () => {
 
   it("Should fetch the schema details", async () => {
     const mockedResponses = new Map();
+    const headers = new Headers();
+    headers.append("cache-control", "max-age=3600");
 
     // Set the response from lookup api with the info about Metadata service.
     mockedResponses.set(
@@ -85,7 +87,8 @@ describe("ArtifactClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -135,7 +138,7 @@ describe("ArtifactClient", () => {
     // Set the response from Metadata service with the versions info from the catalog.
     mockedResponses.set(
       `https://artifact.data.api.platform.here.com/artifact/v1/schema/hrn:here:schema:::com.here.schema.mock:test_v2:2.38.0`,
-      new Response(JSON.stringify(mockedResponse))
+      new Response(JSON.stringify(mockedResponse), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -153,6 +156,8 @@ describe("ArtifactClient", () => {
 
   it("Should fetch file of the schema", async () => {
     const mockedResponses = new Map();
+    const headers = new Headers();
+    headers.append("cache-control", "max-age=3600");
 
     // Set the response from lookup api with the info about Metadata service.
     mockedResponses.set(
@@ -169,7 +174,8 @@ describe("ArtifactClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -179,12 +185,12 @@ describe("ArtifactClient", () => {
     // Set the response from Metadata service with the versions info from the catalog.
     mockedResponses.set(
       `https://artifact.data.api.platform.here.com/artifact/v1/artifact/hrn:here:artifact:::com.here.schema.fake:100500-v2`,
-      new Response(mockedResponse)
+      new Response(mockedResponse, { headers })
     );
 
     mockedResponses.set(
       `https://artifact.data.api.platform.here.com/artifact/v1/artifact/hrn:here:artifact:::com.here.schema.fake:100702-v2`,
-      new Response(mockedResponse2)
+      new Response(mockedResponse2, { headers })
     );
 
     // Setup the fetch to use mocked responses.

--- a/tests/integration/CatalogClient.test.ts
+++ b/tests/integration/CatalogClient.test.ts
@@ -40,6 +40,8 @@ describe("CatalogClient", () => {
   let fetchStub: sinon.SinonStub;
   let catalogClient: CatalogClient;
   let settings: OlpClientSettings;
+  const headers = new Headers();
+  headers.append("cache-control", "max-age=3600");
 
   before(() => {
     sandbox = sinon.createSandbox();
@@ -88,7 +90,8 @@ describe("CatalogClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -148,7 +151,7 @@ describe("CatalogClient", () => {
     // Set the response from Metadata service with the versions info from the catalog.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions?startVersion=2&endVersion=4`,
-      new Response(JSON.stringify(mockedVersions))
+      new Response(JSON.stringify(mockedVersions), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -187,7 +190,8 @@ describe("CatalogClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -278,12 +282,12 @@ describe("CatalogClient", () => {
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify(mockedVersions))
+      new Response(JSON.stringify(mockedVersions), { headers })
     );
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions?startVersion=-1`,
-      new Response(JSON.stringify(mockedVersions))
+      new Response(JSON.stringify(mockedVersions), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -322,7 +326,8 @@ describe("CatalogClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -353,7 +358,7 @@ describe("CatalogClient", () => {
     // Set the response from Metadata service with the versions info from the catalog.
     mockedResponses.set(
       `https://config.data.api.platform.here.com/config/v1/catalogs/hrn:here:data:::test-hrn`,
-      new Response(JSON.stringify(mockedCatalogs))
+      new Response(JSON.stringify(mockedCatalogs), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -386,7 +391,8 @@ describe("CatalogClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -417,7 +423,7 @@ describe("CatalogClient", () => {
     // Set the response from Metadata service with the versions info from the catalog.
     mockedResponses.set(
       `https://config.data.api.platform.here.com/config/v1/catalogs/hrn:here:data:::test-hrn`,
-      new Response(JSON.stringify(mockedCatalog))
+      new Response(JSON.stringify(mockedCatalog), { headers })
     );
 
     // Setup the fetch to use mocked responses.

--- a/tests/integration/VersionedLayerClient.test.ts
+++ b/tests/integration/VersionedLayerClient.test.ts
@@ -44,6 +44,8 @@ describe("VersionedLayerClient", () => {
 
   const testHRN = HRN.fromString("hrn:here:data:::test-hrn");
   const testLayerId = "test-layed-id";
+  const headers = new Headers();
+  headers.append("cache-control", "max-age=3600");
 
   before(() => {
     sandbox = sinon.createSandbox();
@@ -138,13 +140,14 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     mockedResponses.set(
       `https://query.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 128 }))
+      new Response(JSON.stringify({ version: 128 }), { headers })
     );
 
     // Set the response with mocked partitions for IDs 100 and 1000 from Query service
@@ -172,7 +175,8 @@ describe("VersionedLayerClient", () => {
               version: 2
             }
           ]
-        })
+        }),
+        { headers }
       )
     );
 
@@ -239,14 +243,15 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response from Metadata service with the info about latest catalog version.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 128 }))
+      new Response(JSON.stringify({ version: 128 }), { headers })
     );
 
     // Set the response of mocked partitions from metadata service.
@@ -293,7 +298,8 @@ describe("VersionedLayerClient", () => {
             }
           ],
           next: "/uri/to/next/page"
-        })
+        }),
+        { headers }
       )
     );
 
@@ -373,20 +379,21 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://blob.data.api.platform.here.com/blob/v1/layers/test-layed-id/data/1b2ca68f-d4a0-4379-8120-cd025640510c`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Set the response from Metadata service with the info about latest catalog version.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 128 }))
+      new Response(JSON.stringify({ version: 128 }), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -430,12 +437,12 @@ describe("VersionedLayerClient", () => {
 
     mockedResponses.set(
       `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/partitions?partition=0000042&version=42`,
-      new Response(JSON.stringify(mockedPartitionsIdData))
+      new Response(JSON.stringify(mockedPartitionsIdData), { headers })
     );
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 42 }))
+      new Response(JSON.stringify({ version: 42 }), { headers })
     );
 
     // Set the response from lookup api with the info about Metadata service.
@@ -473,14 +480,15 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://blob.data.api.platform.here.com/blob/v1/layers/test-layed-id/data/3C3BE24A341D82321A9BA9075A7EF498.123`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -524,7 +532,7 @@ describe("VersionedLayerClient", () => {
 
     mockedResponses.set(
       `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/partitions?partition=0000042&version=42`,
-      new Response(JSON.stringify(mockedPartitionsIdData))
+      new Response(JSON.stringify(mockedPartitionsIdData), { headers })
     );
 
     // Set the response from lookup api with the info about Metadata service.
@@ -562,20 +570,21 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://blob.data.api.platform.here.com/blob/v1/layers/test-layed-id/data/3C3BE24A341D82321A9BA9075A7EF498.123`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Set the response from Metadata service with the info about latest catalog version.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 42 }))
+      new Response(JSON.stringify({ version: 42 }), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -623,12 +632,12 @@ describe("VersionedLayerClient", () => {
 
     mockedResponses.set(
       `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/versions/42/quadkeys/23618403/depths/0`,
-      new Response(JSON.stringify(mockedQuadKeyTreeData))
+      new Response(JSON.stringify(mockedQuadKeyTreeData), { headers })
     );
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 42 }))
+      new Response(JSON.stringify({ version: 42 }), { headers })
     );
 
     // Set the response from lookup api with the info about Metadata service.
@@ -666,14 +675,15 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://blob.data.api.platform.here.com/blob/v1/layers/test-layed-id/data/c9116bb9-7d00-44bf-9b26-b4ab4c274665`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -719,7 +729,7 @@ describe("VersionedLayerClient", () => {
 
     mockedResponses.set(
       `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/versions/42/quadkeys/23618403/depths/0`,
-      new Response(JSON.stringify(mockedQuadKeyTreeData))
+      new Response(JSON.stringify(mockedQuadKeyTreeData), { headers })
     );
 
     // Set the response from lookup api with the info about Metadata service.
@@ -757,20 +767,21 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://blob.data.api.platform.here.com/blob/v1/layers/test-layed-id/data/c9116bb9-7d00-44bf-9b26-b4ab4c274665`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Set the response from Metadata service with the info about latest catalog version.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 42 }))
+      new Response(JSON.stringify({ version: 42 }), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -832,7 +843,8 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -865,13 +877,14 @@ describe("VersionedLayerClient", () => {
               version: 1
             }
           ]
-        })
+        }),
+        { headers }
       )
     );
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1&billingTag=billingTag`,
-      new Response(JSON.stringify({ version: 42 }))
+      new Response(JSON.stringify({ version: 42 }), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -967,20 +980,21 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response from Metadata service with the info about latest catalog version.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 30 }))
+      new Response(JSON.stringify({ version: 30 }), { headers })
     );
 
     // Set the response of mocked partitions with additional fields.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/layers/test-layed-id/partitions?version=30&additionalFields=dataSize,checksum,compressedDataSize`,
-      new Response(JSON.stringify(mockedPartitions))
+      new Response(JSON.stringify(mockedPartitions), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -1027,7 +1041,7 @@ describe("VersionedLayerClient", () => {
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 30 }))
+      new Response(JSON.stringify({ version: 30 }), { headers })
     );
 
     // Set the response from lookup api with the info about Query API.
@@ -1055,7 +1069,8 @@ describe("VersionedLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -1084,7 +1099,7 @@ describe("VersionedLayerClient", () => {
     // Set the response of mocked partitions with additional fields.
     mockedResponses.set(
       `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/versions/30/quadkeys/70/depths/0?additionalFields=dataSize,checksum,compressedDataSize`,
-      new Response(JSON.stringify(mockedPartitions))
+      new Response(JSON.stringify(mockedPartitions), { headers })
     );
 
     // Setup the fetch to use mocked responses.

--- a/tests/integration/VolatileLayerClient.test.ts
+++ b/tests/integration/VolatileLayerClient.test.ts
@@ -44,6 +44,8 @@ describe("VolatileLayerClient", () => {
 
   const testHRN = HRN.fromString("hrn:here:data:::test-hrn");
   const testVolatileLayerId = "test-layed-id";
+  const headers = new Headers();
+  headers.append("cache-control", "max-age=3600");
 
   before(() => {
     sandbox = sinon.createSandbox();
@@ -91,7 +93,8 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -120,7 +123,8 @@ describe("VolatileLayerClient", () => {
               version: 2
             }
           ]
-        })
+        }),
+        { headers }
       )
     );
 
@@ -213,19 +217,20 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     mockedResponses.set(
       `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/partitions?partition=0000042`,
-      new Response(JSON.stringify(mockedPartitionsIdData))
+      new Response(JSON.stringify(mockedPartitionsIdData), { headers })
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://volatile-blob.data.api.platform.here.com/volatile-blob/v1/layers/test-layed-id/data/3C3BE24A341D82321A9BA9075A7EF498.123`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -267,7 +272,8 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -295,7 +301,8 @@ describe("VolatileLayerClient", () => {
             }
           ],
           next: "/uri/to/next/page"
-        })
+        }),
+        { headers }
       )
     );
 
@@ -367,14 +374,15 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://volatile-blob.data.api.platform.here.com/volatile-blob/v1/layers/test-layed-id/data/1b2ca68f-d4a0-4379-8120-cd025640510c`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -438,7 +446,8 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -460,14 +469,15 @@ describe("VolatileLayerClient", () => {
               dataHandle: "da51785a-54b0-40cd-95ac-760f56fe5457"
             }
           ]
-        })
+        }),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions from metadata service.
     mockedResponses.set(
       `https://volatile-blob.data.api.platform.here.com/volatile-blob/v1/layers/test-layed-id/data/c9116bb9-7d00-44bf-9b26-b4ab4c274665`,
-      new Response(mockedData)
+      new Response(mockedData, { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -475,7 +485,7 @@ describe("VolatileLayerClient", () => {
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 124 }))
+      new Response(JSON.stringify({ version: 124 }), { headers })
     );
 
     const settings = new OlpClientSettings({
@@ -531,13 +541,14 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 30 }))
+      new Response(JSON.stringify({ version: 30 }), { headers })
     );
 
     // Set the response with mocked partitions for volatile layer
@@ -569,7 +580,8 @@ describe("VolatileLayerClient", () => {
               version: 1
             }
           ]
-        })
+        }),
+        { headers }
       )
     );
 
@@ -659,14 +671,15 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
     // Set the response of mocked partitions with additional fields.
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/layers/test-layed-id/partitions?additionalFields=dataSize,checksum,compressedDataSize`,
-      new Response(JSON.stringify(mockedPartitions))
+      new Response(JSON.stringify(mockedPartitions), { headers })
     );
 
     // Setup the fetch to use mocked responses.
@@ -713,7 +726,7 @@ describe("VolatileLayerClient", () => {
 
     mockedResponses.set(
       `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
-      new Response(JSON.stringify({ version: 30 }))
+      new Response(JSON.stringify({ version: 30 }), { headers })
     );
 
     // Set the response from lookup api with the info about Query API.
@@ -741,7 +754,8 @@ describe("VolatileLayerClient", () => {
               additionalProp3: "string"
             }
           }
-        ])
+        ]),
+        { headers }
       )
     );
 
@@ -770,7 +784,7 @@ describe("VolatileLayerClient", () => {
     // Set the response of mocked partitions with additional fields.
     mockedResponses.set(
       `https://query.data.api.platform.here.com/query/v1/layers/test-layed-id/quadkeys/70/depths/0?additionalFields=dataSize,checksum,compressedDataSize`,
-      new Response(JSON.stringify(mockedPartitions))
+      new Response(JSON.stringify(mockedPartitions), { headers })
     );
 
     // Setup the fetch to use mocked responses.


### PR DESCRIPTION
As the end point of the dataservice can be changed over the time, Lookup requests should be re-triggered periodically. For this purpose responses are taken from cache only if expiration time is not over.

* Update getBaseUrl method to keep max-age value from response to keep response in the cache
* Update ApiCacheRepository methods to store different APIs
* Update unit tests
* Update integration tests
* Update Lookup API to return Response to be able to get headers of it

Resolves: OLPEDGE-1607
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>