### PR TITLE
Return HttpError in method getLayerVersions in CatalogClient.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
@@ -130,7 +130,6 @@ export class CatalogClient {
         ).catch(error => Promise.reject(error));
         let requestedCatalogVersion = request.getVersion();
 
-        let latestVersionError: any;
         if (!requestedCatalogVersion) {
             const billingtag = request.getBillingTag();
             const catalogVersionRequest = new CatalogVersionRequest();
@@ -139,31 +138,13 @@ export class CatalogClient {
             }
             requestedCatalogVersion = await this.getLatestVersion(
                 catalogVersionRequest
-            ).catch(error => {
-                latestVersionError = error;
-                return undefined;
-            });
-
-            if (!requestedCatalogVersion) {
-                return Promise.reject(
-                    `Failed to get the latest version with error: ${latestVersionError}`
-                );
-            }
+            ).catch(async error => Promise.reject(error));
         }
 
-        let layerVersionsError: any;
         const layerVersions = await MetadataApi.getLayerVersions(builder, {
             version: requestedCatalogVersion,
             billingTag: request.getBillingTag()
-        }).catch(err => {
-            layerVersionsError = err;
-            return undefined;
-        });
-        if (!layerVersions) {
-            return Promise.reject(
-                `Failed to get layerVersions with error: ${layerVersionsError}`
-            );
-        }
+        }).catch(async error => Promise.reject(new Error(error)));
 
         return Promise.resolve(layerVersions.layerVersions);
     }

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
@@ -149,6 +149,28 @@ describe("CatalogClient", () => {
             });
     });
 
+    it("Should method getLayerVersions return HttpError when MetadataApi.getLayerVersions crashes", async () => {
+        const testError = "Can not get catalog layer version";
+
+        getLayerVersionsStub.callsFake(
+            (builder: any, params: any): Promise<MetadataApi.LayerVersions> => {
+                return Promise.reject("Can not get catalog layer version");
+            }
+        );
+
+        const catalogRequest = new dataServiceRead.LayerVersionsRequest().withVersion(
+            3
+        );
+        const response = await catalogClient
+            .getLayerVersions(
+                (catalogRequest as unknown) as dataServiceRead.LayerVersionsRequest
+            )
+            .catch((err: any) => {
+                assert.isDefined(err);
+                expect(err.message).to.be.equal(testError);
+            });
+    });
+
     it("Should method getLayerVersions provide data with version parameter", async () => {
         const mockedVersion = {
             layerVersions: [


### PR DESCRIPTION
Return HttpError in method getLayerVersions in CatalogClient.
Add Unit Tests for check error in method getLayerVersions.

Resolves: OLPEDGE-1569

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>