### PR TITLE
Unit tests for coverage-api

### DIFF
--- a/@here/olp-sdk-dataservice-api/test/CoverageApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/CoverageApi.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { CoverageApi } from "@here/olp-sdk-dataservice-api";
+import { RequestBuilder, UrlBuilder } from "../lib/RequestBuilder";
+
+chai.use(sinonChai);
+
+const expect = chai.expect;
+
+describe("CoverageApi", () => {
+    it("getDataCoverageAdminAreas", async () => {
+        const params = {
+            layerId: "mocked-layerId",
+            datalevel: "mocked-datalevel"
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            request: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-layerId/adminareas?datalevel=mocked-datalevel"
+                );
+                expect(options.method).to.be.equal("GET");
+                return Promise.resolve("success");
+            }
+        };
+        const result = await CoverageApi.getDataCoverageAdminAreas(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+
+        expect(result).to.be.equal("success");
+    });
+
+    it("getDataCoverageSizeMap", async () => {
+        const params = {
+            layerId: "mocked-layerId",
+            datalevel: 12
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-layerId/heatmap/size?datalevel=12"
+                );
+                expect(options.method).to.be.equal("GET");
+                return Promise.resolve("success");
+            }
+        };
+        const result = await CoverageApi.getDataCoverageSizeMap(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+
+        expect(result).to.be.equal("success");
+    });
+
+    it("getDataCoverageSummary", async () => {
+        const params = {
+            layerId: "mocked-layerId"
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            request: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-layerId/summary"
+                );
+                expect(options.method).to.be.equal("GET");
+                return Promise.resolve("success");
+            }
+        };
+        const result = await CoverageApi.getDataCoverageSummary(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+
+        expect(result).to.be.equal("success");
+    });
+
+    it("getDataCoverageTile", async () => {
+        const params = {
+            layerId: "mocked-layerId",
+            datalevel: 12
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-layerId/tilemap?datalevel=12"
+                );
+                expect(options.method).to.be.equal("GET");
+                return Promise.resolve("success");
+            }
+        };
+        const result = await CoverageApi.getDataCoverageTile(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+
+        expect(result).to.be.equal("success");
+    });
+
+    it("getDataCoverageTimeMap", async () => {
+        const params = {
+            layerId: "mocked-layerId",
+            datalevel: 12,
+            catalogHRN: "mocked-catalogHRN"
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-layerId/heatmap/age?datalevel=12&catalogHRN=mocked-catalogHRN"
+                );
+                expect(options.method).to.be.equal("GET");
+                return Promise.resolve("success");
+            }
+        };
+        const result = await CoverageApi.getDataCoverageTimeMap(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+
+        expect(result).to.be.equal("success");
+    });
+});


### PR DESCRIPTION
Adding unit tests for all public functions in the
coverage-api.ts. Updates coverage to the 100%

Resolves: OLPEDGE-1482

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>