### PR TITLE
Update CodeCov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 coverage:
   range: 60..100
-  round: down
+  round: nearest
   precision: 1
   status:
     project:
@@ -16,7 +16,15 @@ coverage:
         paths:
           - ./@here/olp-sdk-fetch
         threshold: 1
+      olp-sdk-dataservice-api:
+        paths:
+          - ./@here/olp-sdk-dataservice-api
+        threshold: 1
 ignore:
   - ./@here/olp-sdk-authentication/test
   - ./@here/olp-sdk-dataservice-read/test
   - ./@here/olp-sdk-fetch/test
+  - ./@here/olp-sdk-dataservice-api/test
+  - tests
+  - scripts
+  - docs


### PR DESCRIPTION
Fix codecoverage precision.
Due to unstable work on CodeCov tool and precission
issues we need to exclude more folders from scanner:
  - ./@here/olp-sdk-dataservice-api/test
  - tests
  - scripts
  - docs

Relates-TO: OLPEDGE-1657

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>