### PR TITLE
Add functional tests for Stream client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test-published-bundles": "cd tests/integration/bundles/umd && tsc && cd - && mocha-puppeteer tests/integration/bundles/umd/olp-sdk-published.test.js --args no-sandbox disable-setuid-sandbox",
     "test-generated-bundles": "cd tests/integration/bundles/umd && tsc && cd - && mocha-puppeteer tests/integration/bundles/umd/olp-sdk-generated.test.js --args no-sandbox disable-setuid-sandbox",
     "integration-test": "nyc mocha --opts ./tests/integration/mocha.opts > ./tests/integration/xunit.xml",
-    "functional-test": "nyc mocha --opts ./tests/functional/mocha.opts",
+    "functional-test": "nyc mocha --opts ./tests/functional/mocha.opts > ./tests/functional/xunit.xml",
     "coverage": "lerna run coverage",
     "codecov": "lerna run codecov",
     "lint": "lerna run lint",

--- a/scripts/linux/psv/travis_build_test_psv.sh
+++ b/scripts/linux/psv/travis_build_test_psv.sh
@@ -46,6 +46,9 @@ npm run codecov && npx codecov
 # Integration tests
 npm run integration-test
 
+# Functional tests
+npm run functional-test
+
 # Test the generated bundles
 npm run test-generated-bundles
 

--- a/tests/functional/StreamLayerReadData.test.ts
+++ b/tests/functional/StreamLayerReadData.test.ts
@@ -33,6 +33,7 @@ const MOCKED_STREAM_LAYER_ID = "mocked-stream-layer-id";
 const MOCKED_CATALOG_WITH_STREAM_LAYER_HRN =
   "hrn:here:data:::mocked-catalog-for-testing-stream-layer";
 const MOCKED_STREAM_BASE_URL = `http://${SERVER_HOST}:${SERVER_PORT}/stream/v2/catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}`;
+const MOCKED_SUBSCRIBTION_ID = "882990694";
 
 import "@here/olp-sdk-fetch";
 
@@ -40,7 +41,10 @@ import {
   OlpClientSettings,
   StreamLayerClient,
   HRN,
-  SubscribeRequest
+  SubscribeRequest,
+  PollRequest,
+  UnsubscribeRequest,
+  SeekRequest
 } from "@here/olp-sdk-dataservice-read";
 
 describe("Stream Layer Client Read Data", async () => {
@@ -52,7 +56,7 @@ describe("Stream Layer Client Read Data", async () => {
   before(async () => {
     await mockserver.start_mockserver({
       serverPort: SERVER_PORT,
-      verbose: true
+      trace: true
     });
     console.log("Started Mocked Server\n");
   });
@@ -65,12 +69,32 @@ describe("Stream Layer Client Read Data", async () => {
     console.log("Stoped Mocked Server\n");
   });
 
-  it("Subscribe to the layer success", async () => {
+  it("Should Subscribe, Read messages, Read Blob and Unsubscribe from the layer", async () => {
     const client = new StreamLayerClient({
       catalogHrn: HRN.fromString(MOCKED_CATALOG_WITH_STREAM_LAYER_HRN),
       layerId: MOCKED_STREAM_LAYER_ID,
       settings: olpClientSettings
     });
+
+    const MOCKED_DATAHANDLE = "iVBORw0KGgoAAAANSUhEU";
+    const MOCKED_DATA =
+      "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAABGdBTUEAALGPC/xhBQAAABhQTFRFvb29AACEAP8AhIKEPb5x2m9E5413aFQirhRuvAMqCw+6kE2BVsa8miQaYSKyshxFvhqdzKx8UsPYk9gDEcY1ghZXcPbENtax8g5T+3zHYufF1Lf9HdIZBfNEiKAAAAAElFTkSuQmCC";
+
+    const MOCKED_MESSAGE = {
+      metaData: {
+        partition: "314010583",
+        checksum: "ff7494d6f17da702862e550c907c0a91",
+        compressedDataSize: 152417,
+        dataSize: 250110,
+        data: "",
+        dataHandle: MOCKED_DATAHANDLE,
+        timestamp: 1517916706
+      },
+      offset: {
+        partition: 7,
+        offset: 38562
+      }
+    };
 
     await mockServerClient(SERVER_HOST, SERVER_PORT)
       .mockAnyResponse([
@@ -85,6 +109,12 @@ describe("Stream Layer Client Read Data", async () => {
                 api: "stream",
                 version: "v2",
                 baseURL: MOCKED_STREAM_BASE_URL,
+                parameters: {}
+              },
+              {
+                api: "blob",
+                version: "v1",
+                baseURL: `http://${SERVER_HOST}:${SERVER_PORT}/blob/v1/catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}`,
                 parameters: {}
               }
             ])
@@ -101,9 +131,96 @@ describe("Stream Layer Client Read Data", async () => {
           httpResponse: {
             statusCode: 200,
             body: JSON.stringify({
-              nodeBaseURL: `/stream/v2/stream-catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}`,
-              subscriptionId: "882990694"
+              nodeBaseURL: `http://${SERVER_HOST}:${SERVER_PORT}/stream/v2/stream-catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}`,
+              subscriptionId: MOCKED_SUBSCRIBTION_ID
             })
+          }
+        },
+        {
+          httpRequest: {
+            path: `/stream/v2/stream-catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}/layers/${MOCKED_STREAM_LAYER_ID}/subscribe`,
+            method: "DELETE",
+            queryStringParameters: {
+              mode: ["serial"],
+              subscriptionId: [MOCKED_SUBSCRIBTION_ID]
+            }
+          },
+          httpResponse: {
+            statusCode: 200,
+            body: "{}"
+          }
+        },
+        {
+          httpRequest: {
+            path: `/stream/v2/stream-catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}/layers/${MOCKED_STREAM_LAYER_ID}/partitions`,
+            method: "GET",
+            queryStringParameters: {
+              mode: ["serial"],
+              subscriptionId: [MOCKED_SUBSCRIBTION_ID]
+            }
+          },
+          httpResponse: {
+            statusCode: 200,
+            body: JSON.stringify({
+              messages: [
+                {
+                  metaData: {
+                    partition: "314010583",
+                    checksum: "ff7494d6f17da702862e550c907c0a91",
+                    compressedDataSize: 152417,
+                    dataSize: 250110,
+                    data:
+                      "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAABGdBTUEAALGPC/xhBQAAABhQTFRFvb29AACEAP8AhIKEPb5x2m9E5413aFQirhRuvAMqCw+6kE2BVsa8miQaYSKyshxFvhqdzKx8UsPYk9gDEcY1ghZXcPbENtax8g5T+3zHYufF1Lf9HdIZBfNEiKAAAAAElFTkSuQmCC",
+                    dataHandle: "",
+                    timestamp: 1517916706
+                  },
+                  offset: {
+                    partition: 7,
+                    offset: 38562
+                  }
+                }
+              ]
+            })
+          }
+        },
+        {
+          httpRequest: {
+            path: `/stream/v2/stream-catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}/layers/${MOCKED_STREAM_LAYER_ID}/offsets`,
+            method: "PUT",
+            queryStringParameters: {
+              mode: ["serial"],
+              subscriptionId: [MOCKED_SUBSCRIBTION_ID]
+            },
+            body: '{"offsets":[{"partition":7,"offset":38562}]}'
+          },
+          httpResponse: {
+            statusCode: 200,
+            body: "{}"
+          }
+        },
+        {
+          httpRequest: {
+            path: `/blob/v1/catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}/layers/${MOCKED_STREAM_LAYER_ID}/data/${MOCKED_DATAHANDLE}`,
+            method: "GET"
+          },
+          httpResponse: {
+            statusCode: 200,
+            body: MOCKED_DATA
+          }
+        },
+        {
+          httpRequest: {
+            path: `/stream/v2/stream-catalogs/${MOCKED_CATALOG_WITH_STREAM_LAYER_HRN}/layers/${MOCKED_STREAM_LAYER_ID}/seek`,
+            method: "PUT",
+            queryStringParameters: {
+              mode: ["serial"],
+              subscriptionId: [MOCKED_SUBSCRIBTION_ID]
+            },
+            body: '{"offsets":[{"partition":7,"offset":38562}]}'
+          },
+          httpResponse: {
+            statusCode: 200,
+            body: "{}"
           }
         }
       ])
@@ -118,9 +235,96 @@ describe("Stream Layer Client Read Data", async () => {
         }
       );
 
+    // Test subscribtion
     const subscriptionId = await client.subscribe(
       new SubscribeRequest().withMode("serial")
     );
-    expect(subscriptionId).equal("882990694");
+    expect(subscriptionId).equal(MOCKED_SUBSCRIBTION_ID);
+
+    // Test pull messages
+    const messages = await client.poll(
+      new PollRequest().withMode("serial").withSubscriptionId(subscriptionId)
+    );
+    expect(messages.length).equals(1);
+    expect(messages[0].metaData.partition).equals("314010583");
+
+    // Test unsubscribtion
+    const unsubscribeResponse = await client.unsubscribe(
+      new UnsubscribeRequest()
+        .withMode("serial")
+        .withSubscriptionId(MOCKED_SUBSCRIBTION_ID)
+    );
+    expect(unsubscribeResponse.status).equals(200);
+
+    // Test reading blob
+    const data = await client.getData(MOCKED_MESSAGE).then(res => res.text());
+    expect(data).equals(MOCKED_DATA);
+
+    // Test seek method
+    const seekResponse = await client.seek(
+      new SeekRequest()
+        .withSubscriptionId(MOCKED_SUBSCRIBTION_ID)
+        .withMode("serial")
+        .withSeekOffsets({
+          offsets: [
+            {
+              partition: 7,
+              offset: 38562
+            }
+          ]
+        })
+    );
+    expect(seekResponse.status).equals(200);
+
+    // Test handle "nodatahandle" error
+    const getDataResponse = await client
+      .getData({
+        metaData: {
+          partition: "314010583",
+          checksum: "ff7494d6f17da702862e550c907c0a91",
+          compressedDataSize: 152417,
+          dataSize: 250110,
+          data:
+            "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAABGdBTUEAALGPC/xhBQAAABhQTFRFvb29AACEAP8AhIKEPb5x2m9E5413aFQirhRuvAMqCw+6kE2BVsa8miQaYSKyshxFvhqdzKx8UsPYk9gDEcY1ghZXcPbENtax8g5T+3zHYufF1Lf9HdIZBfNEiKAAAAAElFTkSuQmCC",
+          dataHandle: "",
+          timestamp: 1517916706
+        },
+        offset: {
+          partition: 7,
+          offset: 38562
+        }
+      })
+      .catch(err => err.message);
+    expect(getDataResponse).equals("No data handle for this partition");
+
+    // Test subscribtion error handling
+    const subscribeResponse = await client
+      .subscribe(
+        new SubscribeRequest()
+          .withConsumerId("test-id")
+          .withSubscriptionProperties({})
+      )
+      .catch(err => err.message);
+    expect(subscribeResponse).equals("Not Found");
+
+    // Test Poll error handling
+    const pollResponse = await client
+      .poll(new PollRequest())
+      .catch(err => err.message);
+    expect(pollResponse).equals("Not Found");
+
+    client["subscribtionNodeBaseUrl"] = undefined;
+    const pollResponse2 = await client
+      .poll(new PollRequest())
+      .catch(err => err.message);
+    expect(pollResponse2).equals(
+      "No valid nodeBaseurl provided for the subscribtion id=undefined, please check your subscribtion"
+    );
+
+    // Test Seek error handling
+    const seekResponseErr = await client
+      .seek(new SeekRequest())
+      .catch(err => err.message);
+    expect(seekResponseErr).equals("Error: offsets are required.");
   });
 });


### PR DESCRIPTION
Adding functional tests with mocked HTTP
responses for stream layer client.

Tests covering the client 84% and checks all public
methods.

Resolves: OLPEDGE-1531

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>