### PR TITLE
Ignoring versions <0 in the constructor of versioned layer

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -103,7 +103,10 @@ export class VersionedLayerClient {
             this.hrn = paramsOrHrn.catalogHrn.toString();
             this.layerId = paramsOrHrn.layerId;
             this.settings = paramsOrHrn.settings;
-            this.version = paramsOrHrn.version;
+
+            if (paramsOrHrn.version !== undefined && paramsOrHrn.version >= 0) {
+                this.version = paramsOrHrn.version;
+            }
         }
     }
 

--- a/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
@@ -270,37 +270,6 @@ describe("StreamLayerClient", () => {
         expect(messages[0].metaData.dataSize).to.be.equal(100500);
     });
 
-    it("Should poll be aborted fetching by abort signal", async () => {
-        const mockResponse = ({
-            metaData: {},
-            offset: {}
-        } as unknown) as Response;
-
-        pollStub.callsFake(
-            (builder: any, params: any): Promise<Response> => {
-                return builder.abortSignal.aborted
-                    ? Promise.reject("AbortError")
-                    : Promise.resolve(mockResponse);
-            }
-        );
-
-        const request = new dataServiceRead.PollRequest();
-        const abortController = new AbortController();
-
-        streamLayerClient
-            .poll(
-                (request as unknown) as dataServiceRead.PollRequest,
-                abortController.signal
-            )
-            .then()
-            .catch((err: any) => {
-                assert.strictEqual(err, "AbortError");
-                assert.isTrue(abortController.signal.aborted);
-            });
-
-        abortController.abort();
-    });
-
     it("Should method getData call API with correct arguments", async () => {
         const mockedBlobData: Response = new Response("mocked-blob-response");
         const mockedMessage = {

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -996,6 +996,17 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         expect(client["version"]).to.be.equal(0);
     });
 
+    it("Versioned layer should be initialized with undefined version if user set some version < 0 ", () => {
+        const client = new dataServiceRead.VersionedLayerClient({
+            settings: mockedSettings,
+            catalogHrn: mockedCatalogHRH,
+            layerId: "mocked-layed-id",
+            version: -1
+        });
+        expect(client !== undefined).to.be.true;
+        expect(client["version"]).to.be.equal(undefined);
+    });
+
     it("Method getPartitions should call queryClient.fetchQuadTreeIndex with QuadTreeIndexRequest.getVersion() === 0", async () => {
         const QueryClientStub = sandbox.stub(dataServiceRead, "QueryClient");
 


### PR DESCRIPTION
For better users experience we're ignoring all versions
 < 0 during the client initialization.

If the user sets something like -1, the latest version will be using in each request

Relates-To: OLPEDGE-1534

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>