### PR TITLE
Add improvement to CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ rv_job:
   - docker-prod
   image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PERFORMANCE}:${DOCKER_IMAGE_PERFORMANCE_VERSION}
   script:
+  - npm install -g yarn
   - yarn
   - yarn bootstrap
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ addons:
 branches:
     only:
       - master
-script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh && echo "Event $TRAVIS_EVENT_TYPE, Message $TRAVIS_COMMIT_MESSAGE"
+script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh && env
 name: "PSV Linux Build & Test"
 
 deploy:
   - provider: script
-    script: $WORKSPACE/scripts/publish-packages.sh && echo "Event $TRAVIS_EVENT_TYPE, Message $TRAVIS_COMMIT_MESSAGE"
+    script: $WORKSPACE/scripts/publish-packages.sh
     cleanup: false
     on:
        branch: master
-       condition: [ $TRAVIS_EVENT_TYPE = api && $TRAVIS_COMMIT_MESSAGE = 'Publish to NPM' ]
+       condition: [ $TRAVIS_EVENT_TYPE = api && $allow_publish_npm = true ]


### PR DESCRIPTION
Update travis and gitlab yml files with minor fixes.
Gitlab job need yarn to be global.
Travis deply job should start only:
- if job started by API
- and allow_publish_npm is true

Relates-to: OLPEDGE-1376

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>