### PR TITLE
Fix API break.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
@@ -44,12 +44,24 @@ export interface IndexLayerClientParams {
  */
 export class IndexLayerClient {
     private readonly apiVersion: string = "v1";
-    // The HERE Resource Name of the catalog
-    private hrn: string;
-    // The ID of the layer.
-    private layerId: string;
-    // The [[OlpClientSettings]] instance.
-    private settings: OlpClientSettings;
+
+    /**
+     * HRN of the catalog.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    hrn: string;
+
+    /**
+     * The ID of the layer.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    layerId: string;
+
+    /**
+     * The [[OlpClientSettings]] instance.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    settings: OlpClientSettings;
 
     /**
      * @deprecated Please use the overloaded constructor of IndexLayerClient.

--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -56,12 +56,24 @@ export interface VersionedLayerClientParams {
 export class VersionedLayerClient {
     private readonly apiVersion: string = "v1";
 
-    // HRN of the catalog.
-    private hrn: string;
-    // The ID of the layer.
-    private layerId: string;
-    // The [[OlpClientSettings]] instance.
-    private settings: OlpClientSettings;
+    /**
+     * HRN of the catalog.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    hrn: string;
+
+    /**
+     * The ID of the layer.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    layerId: string;
+
+    /**
+     * The [[OlpClientSettings]] instance.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    settings: OlpClientSettings;
+
     // Layer version.
     private version?: number;
 

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -54,12 +54,23 @@ export interface VolatileLayerClientParams {
 export class VolatileLayerClient {
     private readonly apiVersion: string = "v1";
 
-    // The HERE Resource Name of the catalog
-    private hrn: string;
-    // The ID of the layer.
-    private layerId: string;
-    // The [[OlpClientSettings]] instance.
-    private settings: OlpClientSettings;
+    /**
+     * HRN of the catalog.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    hrn: string;
+
+    /**
+     * The ID of the layer.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    layerId: string;
+
+    /**
+     * The [[OlpClientSettings]] instance.
+     * @deprecated This field will be marked as private by 08.2020.
+     */
+    settings: OlpClientSettings;
 
     /**
      * @deprecated Please use the overloaded constructor of VolatileLayerClient.


### PR DESCRIPTION
Make and deprecate the private properties
 public as was before 1.3.0 release to fix API break.

Resolves: OLPEDGE-1691
Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>