### PR TITLE
Split publish script,add 4 conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,26 @@ name: "PSV Linux Build & Test"
 
 deploy:
   - provider: script
-    script: $WORKSPACE/scripts/publish-packages.sh
+    script: $WORKSPACE/scripts/publish-packages.sh -fetch
     cleanup: false
     on:
        branch: master
-       condition: [ $TRAVIS_EVENT_TYPE = api && $allow_publish_npm = true ]
+       condition: [ $TRAVIS_EVENT_TYPE = api && $allow_publish_npm = true && $allow_publish_fetch = true ]
+  - provider: script
+    script: $WORKSPACE/scripts/publish-packages.sh -api
+    cleanup: false
+    on:
+       branch: master
+       condition: [ $TRAVIS_EVENT_TYPE = api && $allow_publish_npm = true && $allow_publish_api = true ]
+  - provider: script
+    script: $WORKSPACE/scripts/publish-packages.sh -auth
+    cleanup: false
+    on:
+       branch: master
+       condition: [ $TRAVIS_EVENT_TYPE = api && $allow_publish_npm = true && $allow_publish_auth = true ]
+  - provider: script
+    script: $WORKSPACE/scripts/publish-packages.sh -read
+    cleanup: false
+    on:
+       branch: master
+       condition: [ $TRAVIS_EVENT_TYPE = api && $allow_publish_npm = true && $allow_publish_read = true ]

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -22,16 +22,27 @@
 
 echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
 
-# olp-sdk-fetch publish
-cd @here/olp-sdk-fetch && npm install && npm publish && cd -
-
-# olp-sdk-dataservice-api publish
-cd @here/olp-sdk-dataservice-api && npm install && npm publish && cd -
-
-# olp-sdk-dataservice-read publish
-cd @here/olp-sdk-dataservice-read && npm install && npm publish && cd -
-
-# olp-sdk-authentication publish
-cd @here/olp-sdk-authentication && npm install && npm publish && cd -
-
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case "$key" in
+        -fetch)
+        # olp-sdk-fetch publish
+        cd @here/olp-sdk-fetch && npm install && npm publish && cd -
+        ;;
+        -api)
+        # olp-sdk-dataservice-api publish
+        cd @here/olp-sdk-dataservice-api && npm install && npm publish && cd -
+        ;;
+        -auth)
+        # olp-sdk-authentication publish
+        cd @here/olp-sdk-authentication && npm install && npm publish && cd -
+        ;;
+        -read)
+        # olp-sdk-dataservice-read publish
+        cd @here/olp-sdk-dataservice-read && npm install && npm publish && cd -
+        ;;
+    esac
+    # Shift after checking all the cases to get the next option
+    shift
+done
 echo 'Publish done!'


### PR DESCRIPTION
Now every service may be published separately.
Publish script will run only when variables:
- $allow_publish_npm
- $allow_publish_SERVICE_NAME
are 'true'.
Variables are defined on Travis.

Relates-to: OLPEDGE-1702

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>