### PR TITLE
Add integration tests for testing API breaks for VersionedLayerClient.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test": "lerna run test",
     "test-published-bundles": "cd tests/integration/bundles/umd && tsc && cd - && mocha-puppeteer tests/integration/bundles/umd/olp-sdk-published.test.js --args no-sandbox disable-setuid-sandbox",
     "test-generated-bundles": "cd tests/integration/bundles/umd && tsc && cd - && mocha-puppeteer tests/integration/bundles/umd/olp-sdk-generated.test.js --args no-sandbox disable-setuid-sandbox",
+    "api-breaks-test": "nyc mocha --opts ./tests/integration/api-breaks/mocha.opts > ./tests/integration/api-breaks/xunit.xml",
     "integration-test": "nyc mocha --opts ./tests/integration/mocha.opts > ./tests/integration/xunit.xml",
     "functional-test": "nyc mocha --opts ./tests/functional/mocha.opts > ./tests/functional/xunit.xml",
     "coverage": "lerna run coverage",

--- a/tests/integration/api-breaks/VersionedLayerClient.test.ts
+++ b/tests/integration/api-breaks/VersionedLayerClient.test.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import {
+  VersionedLayerClient,
+  OlpClientSettings,
+  HRN,
+  VersionedLayerClientParams,
+  QuadKeyPartitionsRequest,
+  DataRequest,
+  PartitionsRequest
+} from "@here/olp-sdk-dataservice-read";
+import { QueryApi, MetadataApi } from "@here/olp-sdk-dataservice-api";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("VersionedLayerClientParams", () => {
+  it("VersionedLayerClientParams with all required params", () => {
+    const params: VersionedLayerClientParams = {
+      catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
+      layerId: "mocked-layer-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("mocked-token")
+      })
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("VersionedLayerClientParams with all required and optional params", () => {
+    const params: VersionedLayerClientParams = {
+      catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
+      layerId: "mocked-layer-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("mocked-token")
+      }),
+      version: 4
+    };
+
+    assert.isDefined(params);
+  });
+});
+
+describe("VersionedLayerClient", () => {
+  class VersionedLayerClientTest extends VersionedLayerClient {
+    constructor(params: VersionedLayerClientParams) {
+      super(params);
+    }
+
+    async getData(
+      dataRequest: DataRequest,
+      abortSignal?: AbortSignal
+    ): Promise<Response> {
+      return Promise.resolve(new Response());
+    }
+
+    async getPartitions(
+      quadKeyPartitionsRequest: QuadKeyPartitionsRequest,
+      abortSignal?: AbortSignal
+    ): Promise<QueryApi.Index>;
+    async getPartitions(
+      partitionsRequest: PartitionsRequest,
+      abortSignal?: AbortSignal
+    ): Promise<MetadataApi.Partitions>;
+
+    async getPartitions(
+      request: QuadKeyPartitionsRequest | PartitionsRequest,
+      abortSignal?: AbortSignal
+    ): Promise<QueryApi.Index | MetadataApi.Partitions | QueryApi.Partitions> {
+      return Promise.resolve({});
+    }
+  }
+
+  beforeEach(() => {
+    VersionedLayerClientTest;
+  });
+
+  it("Shoud be initialized with arguments", async () => {
+    const settings = new OlpClientSettings({
+      environment: "here",
+      getToken: () => Promise.resolve("test-token-string")
+    });
+    const layerClient = new VersionedLayerClient(
+      HRN.fromString("hrn:here:data:::test-hrn"),
+      "test-layed-id",
+      settings
+    );
+    assert.isDefined(layerClient);
+    expect(layerClient).to.be.instanceOf(VersionedLayerClient);
+
+    assert.isFunction(layerClient.getData);
+    assert.isFunction(layerClient.getPartitions);
+    assert.isDefined(layerClient.hrn);
+    assert.isDefined(layerClient.layerId);
+    assert.isDefined(layerClient.settings);
+  });
+
+  it("Shoud be initialized with VersionedLayerClientParams", async () => {
+    const layerClient = new VersionedLayerClient({
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("test-token-string")
+      })
+    });
+    assert.isDefined(layerClient);
+    expect(layerClient).to.be.instanceOf(VersionedLayerClient);
+
+    assert.isFunction(layerClient.getData);
+    assert.isFunction(layerClient.getPartitions);
+    assert.isDefined(layerClient.hrn);
+    assert.isDefined(layerClient.layerId);
+    assert.isDefined(layerClient.settings);
+  });
+
+  it("getPartitions method with QuadKeyPartitionsRequest", async () => {
+    const layerClient = new VersionedLayerClientTest({
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("test-token-string")
+      })
+    });
+
+    const response = layerClient.getPartitions(new QuadKeyPartitionsRequest());
+    assert.isDefined(response);
+  });
+
+  it("getPartitions method with QuadKeyPartitionsRequest and abort signal", async () => {
+    const layerClient = new VersionedLayerClientTest({
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("test-token-string")
+      })
+    });
+
+    const abortController = new AbortController();
+
+    const response = layerClient.getPartitions(
+      new QuadKeyPartitionsRequest(),
+      abortController.signal
+    );
+    assert.isDefined(response);
+  });
+
+  it("getPartitions method with PartitionsRequest", async () => {
+    const layerClient = new VersionedLayerClientTest({
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("test-token-string")
+      })
+    });
+
+    const response = layerClient.getPartitions(new PartitionsRequest());
+    assert.isDefined(response);
+  });
+
+  it("getPartitions method with PartitionsRequest and abort signal", async () => {
+    const layerClient = new VersionedLayerClientTest({
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("test-token-string")
+      })
+    });
+
+    const abortController = new AbortController();
+
+    const response = layerClient.getPartitions(
+      new PartitionsRequest(),
+      abortController.signal
+    );
+    assert.isDefined(response);
+  });
+
+  it("getData method method with dataHandle", async () => {
+    const layerClient = new VersionedLayerClientTest({
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("test-token-string")
+      })
+    });
+
+    const mockedDataHandle = "1b2ca68f-d4a0-4379-8120-cd025640510c";
+    const request = new DataRequest().withDataHandle(mockedDataHandle);
+    const response = await layerClient.getData(request);
+
+    assert.isDefined(response);
+  });
+
+  it("getData method method with dataHandle and abort signal", async () => {
+    const layerClient = new VersionedLayerClientTest({
+      catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
+      layerId: "test-layed-id",
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("test-token-string")
+      })
+    });
+
+    const abortController = new AbortController();
+
+    const mockedDataHandle = "1b2ca68f-d4a0-4379-8120-cd025640510c";
+    const request = new DataRequest().withDataHandle(mockedDataHandle);
+    const response = await layerClient.getData(request, abortController.signal);
+
+    assert.isDefined(response);
+  });
+});

--- a/tests/integration/api-breaks/mocha.opts
+++ b/tests/integration/api-breaks/mocha.opts
@@ -1,0 +1,7 @@
+--require  ts-node/register
+--require source-map-support/register
+--full-trace
+--bail
+--check-leaks
+--reporter xunit
+tests/integration/api-breaks/*.test.ts


### PR DESCRIPTION
Add skeleton for testing api breaks.
We cover with test the public APIs of our SDK to make sure that in the future that changes in the code will not create breaking changes and will not fail the build processes in customers side. The tests do not verify anything of the functional part, except whether our code is complied with, using the possible variants of use of the public APIs.

Add integration tests for testing API breaks for VersionedLayerClient:
* VersionedLayerClientParams with all required params
* VersionedLayerClientParams with all required and optional params
* LayerClient shoud be initialized with arguments
* LayerClient shoud be initialized with VersionedLayerClientParams
* Test getPartitions method with QuadKeyPartitionsRequest
* Test getPartitions method with QuadKeyPartitionsRequest and abort signal
* Test getPartitions method with PartitionsRequest
* Test getPartitions method with PartitionsRequest and abort signal
* Test getData method method with dataHandle
* Test getData method method with dataHandle and abort signal

Relates-To: OLPEDGE-1690

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>