### PR TITLE
Add integration tests for testing API breaks for CatalogRequest.

### DIFF
--- a/tests/integration/api-breaks/CatalogRequest.test.ts
+++ b/tests/integration/api-breaks/CatalogRequest.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import { CatalogRequest } from "@here/olp-sdk-dataservice-read";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("CatalogRequest", () => {
+  class CatalogRequestTest extends CatalogRequest {
+    withBillingTag(tag: string): CatalogRequest {
+      return this;
+    }
+
+    getBillingTag(): string {
+      return "billing-tag";
+    }
+  }
+
+  it("Shoud be initialized", async () => {
+    const catalogRequest = new CatalogRequestTest();
+    assert.isDefined(catalogRequest);
+    expect(catalogRequest).to.be.instanceOf(CatalogRequest);
+
+    assert.isFunction(catalogRequest.withBillingTag);
+    assert.isFunction(catalogRequest.getBillingTag);
+  });
+
+  it("Test withBillingTag method with tag", async () => {
+    const catalogRequest = new CatalogRequestTest();
+
+    const response = catalogRequest.withBillingTag("test-tag");
+    assert.isDefined(response);
+  });
+
+  it("Test getBillingTag method without params", async () => {
+    const catalogRequest = new CatalogRequestTest();
+    catalogRequest.withBillingTag("test-tag");
+
+    const response = catalogRequest.getBillingTag();
+    assert.isDefined(response);
+  });
+});


### PR DESCRIPTION
The tests do not verify anything of the functional part, except whether our code
 is complied with, using all possible variants of the use of the public APIs.

Add integration tests for testing API breaks for CatalogRequest class:

* CatalogRequest shoud be initialized
* Test withBillingTag method with tag
* Test getBillingTag method without params

Relates-To: OLPEDGE-1717

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>