### PR TITLE
Add integration tests for testing API breaks for CatalogsRequest.

### DIFF
--- a/tests/integration/api-breaks/CatalogsRequest.test.ts
+++ b/tests/integration/api-breaks/CatalogsRequest.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import { CatalogsRequest } from "@here/olp-sdk-dataservice-read";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("CatalogsRequest", () => {
+  class CatalogsRequestTest extends CatalogsRequest {
+    withSchema(schemaHrn: string): CatalogsRequest {
+      return this;
+    }
+    getSchema(): string {
+      return "schema-hrn";
+    }
+
+    withBillingTag(tag: string): CatalogsRequest {
+      return this;
+    }
+
+    getBillingTag(): string {
+      return "billing-tag";
+    }
+  }
+
+  it("Shoud be initialized", async () => {
+    const catalogsRequest = new CatalogsRequestTest();
+    assert.isDefined(catalogsRequest);
+    expect(catalogsRequest).to.be.instanceOf(CatalogsRequest);
+
+    assert.isFunction(catalogsRequest.withBillingTag);
+    assert.isFunction(catalogsRequest.getBillingTag);
+  });
+
+  it("Test withSchema method with schemaHrn", async () => {
+    const catalogsRequest = new CatalogsRequestTest();
+
+    const response = catalogsRequest.withSchema("test");
+    assert.isDefined(response);
+  });
+
+  it("Test getSchema method without params", async () => {
+    const catalogsRequest = new CatalogsRequestTest();
+
+    const response = catalogsRequest.getSchema();
+    assert.isDefined(response);
+  });
+
+  it("Test withBillingTag method with tag", async () => {
+    const catalogsRequest = new CatalogsRequestTest();
+
+    const response = catalogsRequest.withBillingTag("test-tag");
+    assert.isDefined(response);
+  });
+
+  it("Test getBillingTag method without params", async () => {
+    const catalogsRequest = new CatalogsRequestTest();
+
+    const response = catalogsRequest.getBillingTag();
+    assert.isDefined(response);
+  });
+});


### PR DESCRIPTION
The tests do not verify anything of the functional part, except whether our code
 is complied with, using all possible variants of the use of the public APIs.

Add integration tests for testing API breaks for CatalogsRequest class:

* CatalogsRequest shoud be initialized
* Test withSchema method with version
* Test getSchema method without params
* Test withBillingTag method with tag
* Test getBillingTag method without params

Relates-To: OLPEDGE-1717

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>