### PR TITLE
Add integration tests for testing API breaks for QuadKeyPartitionsRequest

### DIFF
--- a/tests/integration/api-breaks/QuadKeyPartitionsRequest.test.ts
+++ b/tests/integration/api-breaks/QuadKeyPartitionsRequest.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import { AdditionalFields } from "@here/olp-sdk-dataservice-api";
+import {
+  QuadKeyPartitionsRequest,
+  QuadKey,
+  QuadTreeIndexDepth
+} from "@here/olp-sdk-dataservice-read";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("QuadKeyPartitionsRequest", () => {
+  class QuadKeyPartitionsRequestTest extends QuadKeyPartitionsRequest {
+    withVersion(version?: number): QuadKeyPartitionsRequest {
+      return this;
+    }
+
+    withQuadKey(quadKey: QuadKey): QuadKeyPartitionsRequest {
+      return this;
+    }
+
+    withDepth(depth: QuadTreeIndexDepth): QuadKeyPartitionsRequest {
+      return this;
+    }
+
+    withBillingTag(tag: string): QuadKeyPartitionsRequest {
+      return this;
+    }
+
+    withAdditionalFields(
+      additionalFields: AdditionalFields
+    ): QuadKeyPartitionsRequest {
+      return this;
+    }
+
+    getVersion(): number {
+      return 10;
+    }
+
+    getQuadKey(): QuadKey {
+      return {
+        row: 5,
+        column: 5,
+        level: 5
+      };
+    }
+
+    getDepth(): QuadTreeIndexDepth {
+      return 0;
+    }
+
+    getBillingTag(): string {
+      return "test-billing-tag";
+    }
+
+    getAdditionalFields(): AdditionalFields {
+      return ["dataSize"];
+    }
+  }
+
+  it("Shoud be initialized", async () => {
+    const request = new QuadKeyPartitionsRequest();
+    assert.isDefined(request);
+    expect(request).to.be.instanceOf(QuadKeyPartitionsRequest);
+
+    assert.isFunction(request.withVersion);
+    assert.isFunction(request.getVersion);
+    assert.isFunction(request.withDepth);
+    assert.isFunction(request.getDepth);
+    assert.isFunction(request.withQuadKey);
+    assert.isFunction(request.getQuadKey);
+    assert.isFunction(request.withBillingTag);
+    assert.isFunction(request.getBillingTag);
+    assert.isFunction(request.withAdditionalFields);
+    assert.isFunction(request.getAdditionalFields);
+  });
+
+  it("Test withVersion method with version", async () => {
+    const request = new QuadKeyPartitionsRequestTest();
+
+    const response = request.withVersion(3);
+    assert.isDefined(response);
+  });
+
+  it("Test withVersion method without params", async () => {
+    const request = new QuadKeyPartitionsRequestTest();
+
+    const response = request.withVersion();
+    assert.isDefined(response);
+  });
+
+  it("Test getVersion method without params", async () => {
+    const request = new QuadKeyPartitionsRequestTest();
+
+    const response = request.getVersion();
+    assert.isDefined(response);
+  });
+
+  it("Test withDepth method with depth", async () => {
+    const request = new QuadKeyPartitionsRequestTest();
+
+    const response = request.withDepth(3);
+    assert.isDefined(response);
+  });
+
+  it("Test getDepth method without params", async () => {
+    const request = new QuadKeyPartitionsRequestTest();
+
+    const response = request.getDepth();
+    assert.isDefined(response);
+  });
+
+  it("Test withQuadKey method with quadKey", async () => {
+    const request = new QuadKeyPartitionsRequestTest();
+
+    const response = request.withQuadKey({
+      row: 5,
+      column: 5,
+      level: 5
+    });
+    assert.isDefined(response);
+  });
+
+  it("Test getQuadKey method without params", async () => {
+    const request = new QuadKeyPartitionsRequestTest();
+
+    const response = request.getQuadKey();
+    assert.isDefined(response);
+  });
+
+  it("Test withBillingTag method with tag", async () => {
+    const catalogRequest = new QuadKeyPartitionsRequestTest();
+
+    const response = catalogRequest.withBillingTag("test-tag");
+    assert.isDefined(response);
+  });
+
+  it("Test getBillingTag method without params", async () => {
+    const catalogRequest = new QuadKeyPartitionsRequestTest();
+
+    const response = catalogRequest.getBillingTag();
+    assert.isDefined(response);
+  });
+
+  it("Test withAdditionalFields method with additionalFields", async () => {
+    const catalogRequest = new QuadKeyPartitionsRequestTest();
+
+    const response = catalogRequest.withAdditionalFields(["dataSize"]);
+    assert.isDefined(response);
+  });
+
+  it("Test getAdditionalFields method without params", async () => {
+    const catalogRequest = new QuadKeyPartitionsRequestTest();
+
+    const response = catalogRequest.getAdditionalFields();
+    assert.isDefined(response);
+  });
+});


### PR DESCRIPTION
The tests do not verify anything of the functional part, except whether our code
 is complied with, using all possible variants of the use of the public APIs.

Add integration tests for testing API breaks for QuadKeyPartitionsRequest class:

* QuadKeyPartitionsRequest shoud be initialized
* Test withVersion method with version
* Test withVersion method without params
* Test getVersion method without params
* Test withDepth method with depth
* Test getDepth method without params
* Test withQuadKey method with quadKey
* Test getQuadKey method without params
* Test withBillingTag method with tag
* Test getBillingTag method without params
* Test withAdditionalFields method with additionalFields
* Test getAdditionalFields method without params

Relates-To: OLPEDGE-1717

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>