### PR TITLE
Add integration tests for testing API breaks for BlobApi.

### DIFF
--- a/tests/integration/api-breaks/BlobApi.test.ts
+++ b/tests/integration/api-breaks/BlobApi.test.ts
@@ -1,0 +1,491 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { BlobApi } from "@here/olp-sdk-dataservice-api";
+import {
+  BlobInitResponse,
+  BlobInitResponseCancelLink,
+  BlobInitResponseCompleteLink,
+  BlobInitResponseLinks,
+  BlobInitResponseStatusLink,
+  BlobInitResponseUploadPartLink,
+  MultipartCompletePart,
+  MultipartCompleteRequest,
+  MultipartUploadMetadata,
+  MultipartUploadStatus
+} from "@here/olp-sdk-dataservice-api/lib/blob-api";
+import { mockedRequestBuilder } from "./MockedRequestBuilder";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("BlobApi", () => {
+  it("BlobInitResponse  with all required params", () => {
+    const params: BlobInitResponse = {};
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponse with all required and optional params", () => {
+    const params: BlobInitResponse = {
+      links: {
+        complete: {
+          href: "test",
+          method: "test"
+        },
+
+        _delete: {
+          href: "test",
+          method: "test"
+        },
+
+        status: {
+          href: "test",
+          method: "test"
+        },
+
+        uploadPart: {
+          href: "test",
+          method: "test"
+        }
+      }
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseCancelLink  with all required params", () => {
+    const params: BlobInitResponseCancelLink = {};
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseCancelLink with all required and optional params", () => {
+    const params: BlobInitResponseCancelLink = {
+      href: "test",
+      method: "test"
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseCompleteLink  with all required params", () => {
+    const params: BlobInitResponseCompleteLink = {};
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseCompleteLink with all required and optional params", () => {
+    const params: BlobInitResponseCompleteLink = {
+      href: "test",
+      method: "test"
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseLinks  with all required params", () => {
+    const params: BlobInitResponseLinks = {};
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseLinks with all required and optional params", () => {
+    const params: BlobInitResponseLinks = {
+      complete: {
+        href: "test",
+        method: "test"
+      },
+
+      _delete: {
+        href: "test",
+        method: "test"
+      },
+
+      status: {
+        href: "test",
+        method: "test"
+      },
+
+      uploadPart: {
+        href: "test",
+        method: "test"
+      }
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseStatusLink  with all required params", () => {
+    const params: BlobInitResponseStatusLink = {};
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseStatusLink with all required and optional params", () => {
+    const params: BlobInitResponseStatusLink = {
+      href: "test",
+      method: "test"
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseUploadPartLink  with all required params", () => {
+    const params: BlobInitResponseUploadPartLink = {};
+
+    assert.isDefined(params);
+  });
+
+  it("BlobInitResponseUploadPartLink with all required and optional params", () => {
+    const params: BlobInitResponseUploadPartLink = {
+      href: "test",
+      method: "test"
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartCompletePart  with all required params", () => {
+    const params: MultipartCompletePart = {};
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartCompletePart with all required and optional params", () => {
+    const params: MultipartCompletePart = {
+      etag: "test",
+      number: 1
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartCompleteRequest  with all required params", () => {
+    const params: MultipartCompleteRequest = {};
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartCompleteRequest with all required and optional params", () => {
+    const params: MultipartCompleteRequest = {
+      parts: [
+        {
+          etag: "test",
+          number: 1
+        }
+      ]
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartUploadMetadata  with all required params", () => {
+    const params: MultipartUploadMetadata = {
+      contentType: "test"
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartUploadMetadata with all required and optional params", () => {
+    const params: MultipartUploadMetadata = {
+      contentEncoding: "gzip",
+      contentType: "test"
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartUploadStatus  with all required params", () => {
+    const params: MultipartUploadStatus = {};
+
+    assert.isDefined(params);
+  });
+
+  it("MultipartUploadStatus with all required and optional params", () => {
+    const params: MultipartUploadStatus = {
+      status: "failed"
+    };
+
+    assert.isDefined(params);
+  });
+
+  it("Test cancelMultipartUpload method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      multiPartToken: "mocked-multiPartToken"
+    };
+
+    const result = await BlobApi.cancelMultipartUpload(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test cancelMultipartUpload method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      multiPartToken: "mocked-multiPartToken",
+      billingTag: "mocked-billingTag"
+    };
+
+    const result = await BlobApi.cancelMultipartUpload(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test checkBlobExists method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle"
+    };
+
+    const result = await BlobApi.checkBlobExists(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test checkBlobExists method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag"
+    };
+
+    const result = await BlobApi.checkBlobExists(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test completeMultipartUpload method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      multiPartToken: "mocked-multiPartToken",
+      billingTag: "mocked-billingTag"
+    };
+
+    const result = await BlobApi.completeMultipartUpload(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test completeMultipartUpload method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      multiPartToken: "mocked-multiPartToken",
+      parts: {
+        parts: [{ etag: "mocked-etag", number: 123 }]
+      },
+      billingTag: "mocked-billingTag"
+    };
+
+    const result = await BlobApi.completeMultipartUpload(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test deleteBlob method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle"
+    };
+
+    const result = await BlobApi.deleteBlob(mockedRequestBuilder, params);
+  });
+
+  it("Test deleteBlob method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag"
+    };
+
+    const result = await BlobApi.deleteBlob(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test getBlob method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag"
+    };
+
+    const result = await BlobApi.getBlob(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test getBlob method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag",
+      range: "mocked-range"
+    };
+
+    const result = await BlobApi.getBlob(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test getMultipartUploadStatus method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      multiPartToken: "mocked-multiPartToken"
+    };
+
+    const result = await BlobApi.getMultipartUploadStatus(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test getMultipartUploadStatus method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag",
+      multiPartToken: "mocked-multiPartToken"
+    };
+
+    const result = await BlobApi.getMultipartUploadStatus(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test putBlob method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      body: "mocked-body",
+      contentLength: "mocked-contentLength"
+    };
+
+    const result = await BlobApi.putBlob(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test putBlob method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag",
+      body: "mocked-body",
+      contentLength: "mocked-contentLength"
+    };
+
+    const result = await BlobApi.putBlob(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test startMultipartUpload method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag"
+    };
+
+    const result = await BlobApi.startMultipartUpload(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test startMultipartUpload method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag",
+      body: "mocked-body" as any
+    };
+
+    const result = await BlobApi.startMultipartUpload(
+      mockedRequestBuilder,
+      params
+    );
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test uploadPart method with all required params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      body: "mocked-body",
+      multiPartToken: "mocked-multiPartToken",
+      partNumber: "mocked-partNumber",
+      contentType: "mocked-contentType",
+      contentLength: "mocked-contentLength"
+    };
+
+    const result = await BlobApi.uploadPart(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+
+  it("Test uploadPart method with all required and optional params", async () => {
+    const params = {
+      layerId: "mocked-id",
+      dataHandle: "mocked-datahandle",
+      billingTag: "mocked-billingTag",
+      body: "mocked-body",
+      multiPartToken: "mocked-multiPartToken",
+      partNumber: "mocked-partNumber",
+      contentType: "mocked-contentType",
+      contentLength: "mocked-contentLength"
+    };
+
+    const result = await BlobApi.uploadPart(mockedRequestBuilder, params);
+
+    expect(result).to.be.equal("success");
+  });
+});


### PR DESCRIPTION
The tests do not verify anything of the functional part, except whether our code
 is complied with, using all possible variants of the use of the public APIs.

Add integration tests for testing API breaks for BlobApi:

* BlobInitResponse  with all required params
* BlobInitResponse with all required and optional params
* BlobInitResponseCancelLink  with all required params
* BlobInitResponseCancelLink with all required and optional params
* BlobInitResponseCompleteLink  with all required params
* BlobInitResponseCompleteLink with all required and optional params
* BlobInitResponseLinks  with all required params
* BlobInitResponseLinks with all required and optional params
* BlobInitResponseStatusLink  with all required params
* BlobInitResponseStatusLink with all required and optional params
* BlobInitResponseUploadPartLink  with all required params
* BlobInitResponseUploadPartLink with all required and optional params
* MultipartCompletePart  with all required params
* MultipartCompletePart with all required and optional params
* MultipartCompleteRequest  with all required params
* MultipartCompleteRequest with all required and optional params
* MultipartUploadMetadata  with all required params
* MultipartUploadMetadata with all required and optional params
* MultipartUploadStatus  with all required params
* MultipartUploadStatus with all required and optional params
* Test cancelMultipartUpload method with all required params
* Test cancelMultipartUpload method with all required and optional params
* Test checkBlobExists method with all required params
* Test checkBlobExists method with all required and optional params
* Test completeMultipartUpload method with all required params
* Test completeMultipartUpload method with all required and optional params
* Test deleteBlob method with all required params
* Test deleteBlob method with all required and optional params
* Test getBlob method with all required params
* Test getBlob method with all required and optional params
* Test getMultipartUploadStatus method with all required params
* Test getMultipartUploadStatus method with all required and optional params
* Test putBlob method with all required params
* Test putBlob method with all required and optional params
* Test startMultipartUpload method with all required params
* Test startMultipartUpload method with all required and optional params
* Test uploadPart method with all required params
* Test uploadPart method with all required and optional params

Relates-To: OLPEDGE-1718

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>