### PR TITLE
Bring back command line utility

### DIFF
--- a/@here/olp-sdk-authentication/oauth-requester
+++ b/@here/olp-sdk-authentication/oauth-requester
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+require("./lib/tokenRequester");

--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "browser": "index.web.js",
   "typings": "index",
+  "bin": "oauth-requester",
   "directories": {
     "test": "test",
     "lib": "lib"


### PR DESCRIPTION
"npx @here/olp-sdk-authentication" should now work again as a command
line utility to request a token on the fly