### PR TITLE
Add commit checker job and scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,15 @@ addons:
 branches:
     only:
       - master
-script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh && env
-name: "PSV Linux Build & Test"
-
+matrix:
+  include:
+  - language: node_js
+    name: "PSV Linux Build & Test"
+    script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh && env
+  - language: minimal
+    name: "PSV Commit checker script"
+    script: $WORKSPACE/scripts/misc/commit_checker.sh
+    if: type = pull_request
 deploy:
   - provider: script
     script: $WORKSPACE/scripts/publish-packages.sh -fetch

--- a/scripts/misc/commit_checker.sh
+++ b/scripts/misc/commit_checker.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -e
+#
+# Copyright (C) 2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+#
+
+# This is script for verifying commit message by requirements.
+# Best git and linux practices are included.
+# Requirements can be find in scripts/misc/commit_message_recom.txt
+
+# Saving whole commit message into file for reading below
+echo "`git log --pretty=format:'%B' -2 | sed '1d' | sed '1d' `" >> commit.log
+
+# Counting number of lines in file
+num_lines=`wc -l commit.log| cut -d'c' -f1` 
+
+# Loop for every line in file
+for (( line=1; line<=${num_lines}; line++ ))
+do
+    current_line_len=`cat commit.log| sed -n ${line}p |wc -m | sed 's/\ \ \ \ \ \ /''/g' `
+    if [ $line -eq 1 ] && [ ${current_line_len} -gt 50 ] ; then
+        echo "ERROR: Title is ${current_line_len} length, so it's too long for title. It must be less than 50 chars "
+        exit 1
+    fi
+    if [ $line -eq 2 ] && [ ${current_line_len} -ne 1 ] ; then
+        echo "ERROR: Second line in Commit Message is not zero length"
+        exit 1
+    fi
+    if [ $line -eq 3 ] && [ ${current_line_len} -lt 1 ] && [ -n $(cat commit.log| sed -n ${line}p | grep 'See also: ') ] && [ -n $(cat commit.log| sed -n ${line}p | grep 'Relates-To: ') ] && [ -n $(echo ${current_line_len}| grep 'Resolves: ') ] ; then
+        echo "ERROR: No details added to commit message besides title starting from 3rd line."
+        exit 1
+    fi
+    if [ ${current_line_len} -gt 72 ] ; then
+        echo "ERROR: ${current_line_len} chars in ${line}-th line is too long. This line must be less than 72 chars"
+        exit 1
+    fi
+    echo " ${line}-th line is ${current_line_len} chars length"
+done
+
+relates_to=$(cat commit.log | grep 'Relates-To: ') || true
+resolves=$(cat commit.log | grep 'Resolves: ') || true
+see=$(cat commit.log | grep 'See also: ') || true
+
+echo "Reference like:  ${relates_to} ${resolves} ${see}  was found in commit message."
+
+if [[ -n ${relates_to} || -n ${resolves} || -n ${see} ]] ; then
+    echo "Commit message contains issue reference. OK."
+else
+    echo ""
+    echo "ERROR: Commit message does not contain ticket or issue reference like Relates-To: or Resolves: or See also:  "
+    echo ""
+    echo "Please read following rules:"
+    cat scripts/misc/commit_message_recom.txt
+    exit 1
+fi

--- a/scripts/misc/commit_message_recom.txt
+++ b/scripts/misc/commit_message_recom.txt
@@ -1,0 +1,34 @@
+#######################################################################
+#######################################################################
+Summarize changes in around 50 characters or less.
+
+More detailed explanatory text. Wrap it to about 72
+characters or so. In some contexts, the first line is treated as the
+subject of the commit and the rest of the text as the body. The
+blank line separating the summary from the body is critical (unless
+you omit the body entirely); various tools like `log`, `shortlog`
+and `rebase` can get confused if you run the two together.
+
+Explain the problem that this commit is solving. Focus on why you
+are making this change as opposed to how (the code explains that).
+Are there side effects or other unintuitive consequences of this
+change? Here's the place to explain them.
+
+Further paragraphs come after blank lines.
+
+- Bullet points are okay, too.
+
+- Typically a hyphen or asterisk is used for the bullet, preceded
+  by a single space, with blank lines in between, but conventions
+  vary here.
+
+All commits need to reference a ticket (ABC-333) or Github issue (#123),
+again separated by a blank line from the commit message summary above:
+
+Resolves: ABC-111, #123
+Relates-To: ABC-333, #321
+See also: ABC-432, #456, #789
+
+Signed-off-by: FirstName LastName <firstname.lastname@company.com>
+#######################################################################
+#######################################################################


### PR DESCRIPTION
Separate job must run only on PR stage.
Job verify commit message and fails if
requirements are not met.
Requirements added into file:
 - scripts/misc/commit_message_recom.txt

Relates-To: OLPEDGE-1573

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>