### PR TITLE
Add integration tests for testing API breaks for KeyValueCache.

### DIFF
--- a/tests/integration/api-breaks/HttpError.test.ts
+++ b/tests/integration/api-breaks/HttpError.test.ts
@@ -28,16 +28,6 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("HttpError", () => {
-  class HttpErrorTest extends HttpError {
-    constructor(status: number, message: string) {
-      super(status, message);
-    }
-
-    isHttpError(error: any): error is HttpError {
-      return error.name === "HttpError";
-    }
-  }
-
   it("Shoud be initialized with arguments", async () => {
     const testError = new HttpError(101, "Test Error");
     assert.isDefined(testError);
@@ -45,13 +35,6 @@ describe("HttpError", () => {
     expect(testError).to.be.instanceOf(HttpError);
     assert.isDefined(testError.status);
     assert.isDefined(testError.message);
-  });
-
-  it("Test isHttpError method with HttpError", async () => {
-    const testError = new HttpErrorTest(101, "Test Error");
-
-    const response = testError.isHttpError(testError);
-    assert.isDefined(response);
   });
 
   it("Test isHttpError method with HttpError", async () => {

--- a/tests/integration/api-breaks/KeyValueCache.test.ts
+++ b/tests/integration/api-breaks/KeyValueCache.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+
+import { KeyValueCache } from "@here/olp-sdk-dataservice-read";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("KeyValueCache", () => {
+  it("Shoud be initialized withouth arguments", async () => {
+    const testKeyValueCache = new KeyValueCache();
+    assert.isDefined(testKeyValueCache);
+
+    expect(testKeyValueCache).to.be.instanceOf(KeyValueCache);
+    assert.isDefined(testKeyValueCache.put);
+    assert.isDefined(testKeyValueCache.get);
+    assert.isDefined(testKeyValueCache.remove);
+  });
+
+  it("Test put method with params", async () => {
+    const testKeyValueCache = new KeyValueCache();
+
+    const response = testKeyValueCache.put("test-key", "test");
+    assert.isTrue(response);
+  });
+
+  it("Test get method with params", async () => {
+    const testKeyValueCache = new KeyValueCache();
+    testKeyValueCache.put("test-key", "test");
+
+    const response = testKeyValueCache.get("test-key");
+    assert.isDefined(response);
+  });
+
+  it("Test remove method with params", async () => {
+    const testKeyValueCache = new KeyValueCache();
+    testKeyValueCache.put("test-key", "test");
+    testKeyValueCache.put("test-key2", "test");
+
+    const response = testKeyValueCache.remove("test-key");
+    assert.isTrue(response);
+  });
+});


### PR DESCRIPTION
The tests do not verify anything of the functional part, except whether our code
is complied with, using all possible variants of the use of the public APIs.

Add integration tests for testing API breaks for KeyValueCache:

* Shoud be initialized withouth arguments
* Test put method with params
* Test get method with params
* Test remove method with params

Relates-To: OLPEDGE-1763

Signed-off-by: Drapak Iryna Angelica <ext-iryna.drapak@here.com>