### PR TITLE
Implement LRU cache

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/cache/LRUCache.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/LRUCache.ts
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { getDataSize } from "../utils";
+/**
+ * Method to assert if flow is not broken.
+ * @param condition boolean. Throw error if false
+ */
+function assert(condition: boolean): void {
+    if (!condition) {
+        throw new Error("ASSERTION failed");
+    }
+}
+
+/** @hidden */
+export class Entry<Key, Value> {
+    constructor(
+        public key: Key,
+        public value: Value,
+        public size: number,
+        public newer: Entry<Key, Value> | null,
+        public older: Entry<Key, Value> | null
+    ) {}
+}
+
+const BYTES_IN_MB = 1048576;
+
+/**
+ * Fixed size cache that evicts its entries in least-recently-used order when it overflows.
+ * Modeled after standard JavaScript `Map` otherwise.
+ */
+export class LRUCache<Key, Value> {
+    private cacheSize = 0;
+    private maxCapacity: number;
+
+    /**
+     * The internal map object that keeps the key-value pairs and their order.
+     */
+    private cache = new Map<Key, Entry<Key, Value>>();
+
+    /**
+     * The newest entry, i.e. the most recently used item.
+     */
+    private newestEntry: Entry<Key, Value> | null = null;
+
+    /**
+     * The oldest entry, i.e. the least recently used item.
+     */
+    private oldestEntry: Entry<Key, Value> | null = null;
+
+    /**
+     * Creates a new instance of `LRUCache`.
+     *
+     * [[capacity]] means then memory used (in MBs).
+     *
+     * @param capacity Number used to configure the maximum cache size in MB.
+     */
+    constructor(capacity: number = 2) {
+        this.maxCapacity = capacity * BYTES_IN_MB;
+    }
+
+    /**
+     * Iterates over all items from the most recently used item to the least recently used one.
+     *
+     * **Note**: Results are undefined if the entire cache is modified during iteration. You may
+     * although modify the current element in [[callbackfn]] function.
+     *
+     * @param callbackfn The callback to call for each item.
+     * @param thisArg Optional this argument for the callback.
+     */
+    forEach(
+        callbackfn: (value: Value, key: Key, map: LRUCache<Key, Value>) => void,
+        thisArg?: any
+    ): void {
+        let entry = this.newestEntry;
+        while (entry !== null) {
+            const older = entry.older;
+            callbackfn.call(thisArg, entry.value, entry.key, this);
+            entry = older;
+        }
+    }
+
+    /**
+     * The size of the cache, i.e. the sum of all the sizes of all the objects in the cache.
+     *
+     * @returns The size of the cache.
+     */
+    getSize(): number {
+        return this.cacheSize;
+    }
+
+    /**
+     * Returns the maximum capacity of the cache, i.e. the maximum number of elements this cache
+     * can contain or the total amount of memory that may be consumed by cache if element size
+     * function was specified in cache c-tor.
+     *
+     * @returns The capacity of the cache.
+     */
+    getCapacity(): number {
+        return this.maxCapacity;
+    }
+
+    /**
+     * Returns the newest entry in the cache.
+     *
+     * @returns Newest entry in the cache.
+     */
+    getNewest(): Entry<Key, Value> | null {
+        return this.newestEntry;
+    }
+
+    /**
+     * Returns the oldest entry in the cache.
+     *
+     * Note: Does not promote the oldest item as most recently used item.
+     *
+     * @returns Oldest entry in the cache.
+     */
+    getOldest(): Entry<Key, Value> | null {
+        return this.oldestEntry;
+    }
+
+    /**
+     * Resets the capacity of this cache. If `newCapacity` is smaller than the current cache size,
+     * all items will be evicted until the cache shrinks to `newCapacity`.
+     *
+     * @param newCapacity The new capacity of this cache.
+     */
+    setCapacity(newCapacity: number): void {
+        this.maxCapacity = newCapacity * BYTES_IN_MB;
+        this.evict();
+    }
+
+    /**
+     * Inserts or updates a key/value pair in the cache.
+     *
+     * If the key already existed in the cache, it will be updated and promoted to the most recently
+     * used item.
+     *
+     * If the key didn't exist in the cache, it will be inserted as most recently used item. An
+     * eviction of the least recently used item takes place if the cache exceeded its capacity.
+     *
+     * Throw error if value size is bigger than cache size. When call this method wrap it in the try/catch block.
+     *
+     * @param key The key for the key-value pair to insert or update.
+     * @param value The value for the key-value pair to insert or update.
+     */
+    set(key: Key, value: Value) {
+        const valueSize = getDataSize(value);
+        let entry = this.cache.get(key);
+        if (entry !== undefined) {
+            this.cacheSize = this.cacheSize - entry.size + valueSize;
+            entry.value = value;
+            entry.size = valueSize;
+            this.promoteEntry(entry);
+            this.evict();
+        } else {
+            if (valueSize > this.maxCapacity) {
+                throw new Error(
+                    "Error. Value size is to big for cache it. Raise cache capacity, please."
+                );
+            }
+
+            entry = new Entry<Key, Value>(key, value, valueSize, null, null);
+            if (this.cache.size === 0) {
+                this.newestEntry = this.oldestEntry = entry;
+            } else {
+                if (this.newestEntry !== null) {
+                    const newest: Entry<Key, Value> = this.newestEntry;
+                    entry.older = this.newestEntry;
+                    newest.newer = entry;
+                    this.newestEntry = entry;
+                } else {
+                    assert(false);
+                }
+            }
+            this.cache.set(key, entry);
+            this.cacheSize += valueSize;
+            this.evict();
+        }
+    }
+
+    /**
+     * Looks up key in the cache and returns the associated value.
+     *
+     * @param key The key to look up.
+     * @returns The associated value, or `undefined` if the key-value pair is not in the cache.
+     */
+    get(key: Key): Value | undefined {
+        const entry = this.cache.get(key);
+        if (entry === undefined) {
+            return undefined;
+        }
+
+        this.promoteEntry(entry);
+        return entry.value;
+    }
+
+    /**
+     * Test if a key/value pair is in the cache.
+     *
+     * @param key The key to look up.
+     * @returns `true` if the key-value pair is in the cache, `false` otherwise.
+     */
+    has(key: Key): boolean {
+        return this.cache.has(key);
+    }
+
+    /**
+     * Clears the cache and removes all stored key-value pairs.
+     */
+    clear(): void {
+        this.newestEntry = this.oldestEntry = null;
+        this.cacheSize = 0;
+        this.cache.clear();
+    }
+
+    /**
+     * Explicitly removes a key-value pair from the cache.
+     *
+     * **Note**: This is an explicit removal, thus, the eviction callback will not be called.
+     *
+     * @param key The key of the key-value pair to delete.
+     * @returns `true` if the key-value pair existed and was deleted, `false` otherwise.
+     */
+    delete(key: Key): boolean {
+        const entry = this.cache.get(key);
+        if (entry === undefined) {
+            return false;
+        }
+        this.deleteEntry(entry);
+        return this.cache.delete(key);
+    }
+
+    protected evict() {
+        while (this.oldestEntry !== null && this.cacheSize > this.maxCapacity) {
+            const evicted = this.evictOldest();
+            if (evicted === undefined) {
+                return;
+            }
+        }
+    }
+
+    protected evictOldest(): Entry<Key, Value> | undefined {
+        if (this.oldestEntry !== null) {
+            const itemToRemove = this.oldestEntry;
+            assert(itemToRemove.older === null);
+
+            this.oldestEntry = itemToRemove.newer;
+            if (itemToRemove.newer !== null) {
+                assert(itemToRemove.newer.older === itemToRemove);
+                itemToRemove.newer.older = null;
+            }
+
+            const isOk = this.cache.delete(itemToRemove.key);
+            assert(isOk === true);
+
+            this.cacheSize -= itemToRemove.size;
+            return itemToRemove;
+        } else {
+            assert(false);
+            return;
+        }
+    }
+
+    private deleteEntry(entry: Entry<Key, Value>): void {
+        if (entry === this.newestEntry) {
+            this.newestEntry = entry.older;
+        } else if (entry.newer) {
+            entry.newer.older = entry.older;
+        } else {
+            assert(false);
+        }
+
+        if (entry === this.oldestEntry) {
+            this.oldestEntry = entry.newer;
+        } else if (entry.older) {
+            entry.older.newer = entry.newer;
+        } else {
+            assert(false);
+        }
+
+        this.cacheSize -= entry.size;
+    }
+
+    private promoteEntry(entry: Entry<Key, Value>): void {
+        if (entry === this.newestEntry) {
+            return;
+        } // already newest, nothing to do
+
+        // re-link newer and older items
+        if (entry.newer) {
+            assert(entry.newer.older === entry);
+            entry.newer.older = entry.older;
+        }
+        if (entry.older) {
+            assert(entry.older.newer === entry);
+            entry.older.newer = entry.newer;
+        }
+        if (entry === this.oldestEntry) {
+            this.oldestEntry = entry.newer;
+        }
+        // re-link ourselves
+        entry.newer = null;
+        entry.older = this.newestEntry;
+
+        // finally, set ourselves as the newest entry
+        if (this.newestEntry !== null) {
+            const newest = this.newestEntry;
+            assert(newest.newer === null);
+            newest.newer = entry;
+            this.newestEntry = entry;
+        } else {
+            assert(false);
+        }
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/cache/index.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/index.ts
@@ -19,3 +19,4 @@
 
 export * from "./ApiCacheRepository";
 export * from "./KeyValueCache";
+export * from "./LRUCache";

--- a/@here/olp-sdk-dataservice-read/lib/utils/getDataSizeUtil.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/getDataSizeUtil.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+const BYTES_IN_NUMBER = 8;
+const BYTES_IN_BOOLEAN = 4;
+
+export function getDataSize(data: any) {
+    let bytes = 0;
+
+    function sizeOf(obj: any) {
+        if (obj !== null && obj !== undefined) {
+            switch (typeof obj) {
+                case "number":
+                    bytes += BYTES_IN_NUMBER;
+                    break;
+                case "string":
+                    bytes += obj.length * 2;
+                    break;
+                case "boolean":
+                    bytes += BYTES_IN_BOOLEAN;
+                    break;
+                case "object":
+                    const objClass = Object.prototype.toString
+                        .call(obj)
+                        // tslint:disable-next-line: no-magic-numbers
+                        .slice(8, -1);
+                    if (objClass === "Object" || objClass === "Array") {
+                        for (const key in obj) {
+                            if (!obj.hasOwnProperty(key)) {
+                                continue;
+                            }
+                            sizeOf(obj[key]);
+                        }
+                    } else {
+                        bytes += obj.toString().length * 2;
+                    }
+                    break;
+            }
+        }
+        return bytes;
+    }
+
+    return sizeOf(data);
+}

--- a/@here/olp-sdk-dataservice-read/lib/utils/index.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/index.ts
@@ -22,3 +22,4 @@ export * from "./RequestBuilderFactory";
 export * from "./getEnvLookupUrl";
 export * from "./validateBillingTag";
 export * from "./validatePartitionsIdsList";
+export * from "./getDataSizeUtil";

--- a/@here/olp-sdk-dataservice-read/test/unit/LRUCache.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/LRUCache.test.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { assert } from "chai";
+import { Entry, LRUCache, getDataSize } from "../../lib";
+
+// tslint:disable:no-string-literal
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+// helper class to access protected members of LRUCache
+class TestLRUCache<Key, Value> extends LRUCache<Key, Value> {
+    assertInternalIntegrity(entries: Key[]): void {
+        // special case - empty cache
+        if (entries.length === 0) {
+            assert.strictEqual(this["cache"].size, 0);
+            assert.isNull(this["newestEntry"]);
+            assert.isNull(this["oldestEntry"]);
+            return;
+        }
+
+        // make sure the map has the correct size
+        assert.strictEqual(this["cache"].size, entries.length);
+
+        assert.isNotNull(this["newestEntry"]);
+        // make sure that the first entry is the newest
+        assert.strictEqual(
+            (this["newestEntry"] as Entry<Key, Value>).key,
+            entries[0]
+        );
+
+        // now walk our linked list
+        for (let i: number = 0; i < entries.length; ++i) {
+            assert.isDefined(this["cache"].get(entries[i]));
+
+            const entry = this["cache"].get(entries[i]) as Entry<Key, Value>;
+            assert.strictEqual(entry.key, entries[i]);
+
+            // special case first element
+            if (i === 0) {
+                assert.strictEqual(entry.newer, null);
+            } else {
+                assert.strictEqual(
+                    (entry.newer as Entry<Key, Value>).key,
+                    entries[i - 1]
+                );
+            }
+
+            if (i === entries.length - 1) {
+                assert.strictEqual(entry.older, null);
+            } else {
+                assert.strictEqual(
+                    (entry.older as Entry<Key, Value>).key,
+                    entries[i + 1]
+                );
+            }
+        }
+
+        // make sure the last entry is the oldest
+        assert.isNotNull(this["oldestEntry"]);
+        assert.strictEqual(
+            (this["oldestEntry"] as Entry<Key, Value>).key,
+            entries[entries.length - 1]
+        );
+    }
+}
+
+describe("LRUCache", function() {
+    it("set", function() {
+        const cache = new LRUCache(3);
+        cache.set(1, 1);
+        cache.set(2, 2);
+        cache.set(3, 3);
+
+        assert.strictEqual(cache.get(1), 1);
+        assert.strictEqual(cache.get(2), 2);
+        assert.strictEqual(cache.get(3), 3);
+        const newest = cache.getNewest();
+        const oldest = cache.getOldest();
+        assert.equal(newest && newest.value, 3);
+        assert.equal(newest && newest.newer, null);
+        assert.equal(oldest && oldest.value, 1);
+        assert.equal(oldest && oldest.older, null);
+
+        cache.clear();
+        cache.set(3, 3);
+        cache.set(3, "some message");
+        const size = getDataSize("some message");
+        assert.equal(cache.getSize(), size);
+    });
+
+    it("get", function() {
+        const cache = new LRUCache<number, number>(3);
+        assert.strictEqual(cache.get(1), undefined);
+        assert.strictEqual(cache.get(2), undefined);
+        cache.set(1, 1);
+        cache.set(2, 2);
+        assert.strictEqual(cache.get(1), 1);
+        assert.strictEqual(cache.get(2), 2);
+        assert.strictEqual(cache.get(0), undefined);
+        assert.strictEqual(cache.getSize(), 16);
+        assert.strictEqual(cache.getCapacity(), 3145728);
+        assert.strictEqual(cache.has(1), true);
+    });
+
+    it("internalIntegrity", function() {
+        const cache = new TestLRUCache<number, number>(3);
+        cache.assertInternalIntegrity([]);
+
+        cache.set(1, 1);
+        cache.assertInternalIntegrity([1]);
+
+        cache.set(2, 2);
+        cache.assertInternalIntegrity([2, 1]);
+
+        cache.set(3, 3);
+        cache.assertInternalIntegrity([3, 2, 1]);
+
+        // reorder the LRU cache
+        assert.strictEqual(cache.get(3), 3);
+        cache.assertInternalIntegrity([3, 2, 1]);
+
+        assert.strictEqual(cache.get(2), 2);
+        cache.assertInternalIntegrity([2, 3, 1]);
+
+        assert.strictEqual(cache.get(1), 1);
+        cache.assertInternalIntegrity([1, 2, 3]);
+
+        cache.set(4, 4);
+        cache.assertInternalIntegrity([4, 1, 2, 3]);
+        assert.strictEqual(cache.get(3), 3);
+        assert.strictEqual(cache.get(6), undefined);
+    });
+
+    it("overflow", function() {
+        const cache = new LRUCache(0.0001);
+        const mockData = {
+            a: "test",
+            b: 42,
+            c: [1, 2, 3, 4, 56, 6],
+            d: "^#%FEVTVJF"
+        };
+        cache.set(1, 1);
+        cache.set(2, 2);
+        cache.set(3, 3);
+        cache.set(4, mockData);
+
+        assert.strictEqual(cache.get(1), undefined);
+        assert.strictEqual(cache.get(2), 2);
+        assert.strictEqual(cache.get(3), 3);
+        assert.strictEqual(cache.get(4), mockData);
+    });
+
+    it("clear", function() {
+        const cache = new LRUCache(3);
+        cache.set(1, 1);
+        cache.set(2, 2);
+        cache.clear();
+
+        assert.strictEqual(cache.get(1), undefined);
+        assert.strictEqual(cache.get(2), undefined);
+    });
+
+    it("iterate", function() {
+        const cache = new LRUCache(3);
+
+        // iterate over empty array, callback must never be called.
+        let i = 1;
+        cache.forEach(() => {
+            assert.fail();
+            ++i;
+        });
+        assert.strictEqual(i, 1);
+
+        cache.set(3, 3);
+        cache.set(2, 2);
+        cache.set(1, 1);
+
+        cache.forEach((key, value) => {
+            assert.strictEqual(key, i);
+            assert.strictEqual(value, i);
+            ++i;
+        });
+
+        assert.strictEqual(i, 4);
+    });
+
+    it("delete", function() {
+        const cache = new TestLRUCache(4);
+
+        // delete the single entry (entry is both newest + oldest)
+        cache.set(1, 1);
+        assert.isTrue(cache.delete(1));
+        assert.isUndefined(cache.get(1));
+        cache.assertInternalIntegrity([]);
+
+        // deleting it again should return false
+        assert.isFalse(cache.delete(1));
+
+        // now delete from the middle, from the end and from the front
+        cache.set(4, 4);
+        cache.set(3, 3);
+        cache.set(2, 2);
+        cache.set(1, 1);
+        assert.isTrue(cache.delete(2));
+        cache.assertInternalIntegrity([1, 3, 4]);
+
+        assert.isTrue(cache.delete(4));
+        cache.assertInternalIntegrity([1, 3]);
+
+        assert.isTrue(cache.delete(1));
+        cache.assertInternalIntegrity([3]);
+
+        assert.isTrue(cache.delete(3));
+        cache.assertInternalIntegrity([]);
+    });
+
+    it("resize", function() {
+        const cache = new TestLRUCache<number, number>(2);
+
+        cache.set(1, 1);
+        cache.set(2, 2);
+
+        assert.strictEqual(cache.getSize(), 16);
+        assert.strictEqual(cache.getCapacity(), 2097152);
+
+        cache.setCapacity(0.00001);
+        assert.strictEqual(cache.getCapacity(), 10.48576);
+        assert.strictEqual(cache.getSize(), 8);
+
+        assert.isFalse(cache.has(1));
+        assert.isTrue(cache.has(2));
+
+        cache.setCapacity(2);
+        cache.set(1, 1);
+
+        assert.strictEqual(cache.getCapacity(), 2097152);
+        assert.strictEqual(cache.getSize(), 16);
+        assert.isTrue(cache.has(1));
+        assert.isTrue(cache.has(2));
+
+        cache.clear();
+        cache.setCapacity(0.0000001);
+        try {
+            cache.set(1, 42);
+        } catch (error) {
+            assert.equal(
+                error.message,
+                "Error. Value size is to big for cache it. Raise cache capacity, please."
+            );
+        }
+    });
+
+    it("customCost", function() {
+        const cache = new TestLRUCache<number, number>(10);
+
+        // fill cache, make sure size is correct
+        cache.set(1, 1);
+        cache.set(2, 2);
+        assert.strictEqual(cache.getSize(), 16);
+        cache.assertInternalIntegrity([2, 1]);
+
+        // delete all inserted items, make sure size is correct
+        cache.delete(2);
+        assert.strictEqual(cache.getSize(), 8);
+        cache.delete(1);
+        assert.strictEqual(cache.getSize(), 0);
+        cache.assertInternalIntegrity([]);
+
+        // overflow cache
+        cache.set(10, 10);
+        assert.strictEqual(cache.getSize(), 8);
+        cache.set(1, 1);
+        assert.strictEqual(cache.getSize(), 16);
+        cache.assertInternalIntegrity([1, 10]);
+
+        // too big to insert, should do nothing
+        try {
+            cache.set(12, 12);
+        } catch (err) {
+            assert.equal(
+                err.message,
+                "Error. Value size is to big for cache it. Raise cache capacity, please."
+            );
+        }
+        cache.assertInternalIntegrity([12, 1, 10]);
+
+        // adding a large item should evict all older ones
+        cache.clear();
+        cache.set(4, 4);
+        cache.set(5, 5);
+        cache.set(9, 9);
+        cache.assertInternalIntegrity([9, 5, 4]);
+    });
+});


### PR DESCRIPTION
LRUcache implementation is needed to have total control over the cache.
Memory managing will be more easy and predictive.

* create LRU cache class
* create unit-tests for LRU cache

Resolves: OLPEDGE-1665
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>