### PR TITLE
Update test coverage for LRU cache

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/index.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/index.ts
@@ -44,3 +44,4 @@ export * from "./SubscribeRequest";
 export * from "./PollRequest";
 export * from "./UnsubscribeRequest";
 export * from "./SeekRequest";
+export * from "./FetchOptions";

--- a/@here/olp-sdk-dataservice-read/test/unit/LRUCache.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/LRUCache.test.ts
@@ -117,6 +117,13 @@ describe("LRUCache", function() {
         assert.strictEqual(cache.getSize(), 16);
         assert.strictEqual(cache.getCapacity(), 3145728);
         assert.strictEqual(cache.has(1), true);
+
+        const cache2 = new LRUCache<string, any>();
+        cache2.set("key", {
+            num: 42,
+            hasBool: true
+        });
+        assert.equal(cache.getSize(), 16);
     });
 
     it("internalIntegrity", function() {

--- a/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/RequestBuilderFactory.test.ts
@@ -380,7 +380,7 @@ describe("RequestFactory", () => {
             }
         });
 
-        xit("Should return correct base url for resource service from cache while max-age is valid", async () => {
+        it("Should return correct base url for resource service from cache while max-age is valid", async () => {
             const headers = new Headers();
             headers.append("cache-control", "max-age=2");
             const response = {

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -51,19 +51,20 @@ describe("VersionedLayerClient", () => {
 
     before(() => {
         sandbox = sinon.createSandbox();
-        let settings = sandbox.createStubInstance(
-            dataServiceRead.OlpClientSettings
-        );
+        let settings = new dataServiceRead.OlpClientSettings({
+            environment: "here",
+            getToken: () => Promise.resolve("token")
+        });
         versionedLayerClient = new dataServiceRead.VersionedLayerClient(
             mockedHRN,
             mockedLayerId,
-            (settings as unknown) as dataServiceRead.OlpClientSettings
+            settings
         );
 
         const versionedLayerClientParams = {
             catalogHrn: mockedHRN,
             layerId: mockedLayerId,
-            settings: (settings as unknown) as dataServiceRead.OlpClientSettings,
+            settings,
             version: 5
         };
 
@@ -74,7 +75,7 @@ describe("VersionedLayerClient", () => {
         const versionedLayerClientParamsWithoutVersion = {
             catalogHrn: mockedHRN,
             layerId: mockedLayerId,
-            settings: (settings as unknown) as dataServiceRead.OlpClientSettings
+            settings
         };
 
         versionedLayerClientWithoutVersion = new dataServiceRead.VersionedLayerClient(
@@ -472,7 +473,7 @@ describe("VersionedLayerClient", () => {
         abortController.abort();
     });
 
-    xit("Should method getPartitions provide data with PartitionsRequest", async () => {
+    it("Should method getPartitions provide data with PartitionsRequest", async () => {
         const mockedVersion = {
             version: 42
         };
@@ -514,7 +515,7 @@ describe("VersionedLayerClient", () => {
         expect(partitions).to.be.equal(mockedPartitions);
     });
 
-    xit("Should method getPartitions provide data with PartitionIds list", async () => {
+    it("Should method getPartitions provide data with PartitionIds list", async () => {
         const mockedIds = ["1", "2", "13", "42"];
         const mockedVersion = {
             version: 42
@@ -701,7 +702,7 @@ describe("VersionedLayerClient", () => {
         ).to.be.equal("compressedDataSize");
     });
 
-    xit("Should baseUrl error be handled", async () => {
+    it("Should baseUrl error be handled", async () => {
         const mockedErrorResponse = "Bad response";
         const dataHandleRequest = new dataServiceRead.DataRequest().withDataHandle(
             "moсked-data-handle"
@@ -740,7 +741,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    xit("Should latestVersion error be handled", async () => {
+    it("Should latestVersion error be handled", async () => {
         const mockedErrorResponse = "Bad response";
         const dataPartitionRequest = new dataServiceRead.DataRequest().withPartitionId(
             "mocked-id"
@@ -874,7 +875,7 @@ describe("VersionedLayerClient", () => {
         }
     });
 
-    xit("Should getPartitions fetch menadata with latest layer version if not defined", async () => {
+    it("Should getPartitions fetch menadata with latest layer version if not defined", async () => {
         getVersionStub.callsFake(() => Promise.resolve({ version: 5 }));
 
         getPartitionsStub.callsFake((builder, params) => {
@@ -892,11 +893,12 @@ describe("VersionedLayerClient", () => {
             getBillingTag: () => undefined,
             getPartitionIds: () => undefined,
             getAdditionalFields: () => undefined,
-            getVersion: () => undefined
+            getVersion: () => undefined,
+            getFetchOption: () => dataServiceRead.FetchOptions.OnlineOnly
         } as any);
     });
 
-    xit("Should getPartitions fetch menadata with set layer version in constructor", async () => {
+    it("Should getPartitions fetch menadata with set layer version in constructor", async () => {
         getPartitionsStub.callsFake((builder, params) => {
             assert.equal(params.version, 6);
             return Promise.resolve();
@@ -913,7 +915,8 @@ describe("VersionedLayerClient", () => {
             getBillingTag: () => undefined,
             getPartitionIds: () => undefined,
             getAdditionalFields: () => undefined,
-            getVersion: () => undefined
+            getVersion: () => undefined,
+            getFetchOption: () => dataServiceRead.FetchOptions.OnlineOnly
         } as any);
     });
 
@@ -1093,7 +1096,7 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         );
     });
 
-    xit("Method getPartitions should call MetadataApi.getPartitions with param version === 0", async () => {
+    it("Method getPartitions should call MetadataApi.getPartitions with param version === 0", async () => {
         // @ts-ignore
         class VersionedLayerClientTest extends dataServiceRead.VersionedLayerClient {
             constructor(params: dataServiceRead.VersionedLayerClientParams) {
@@ -1123,7 +1126,7 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
 
         getPartitionsStub.callsFake((builder, params: any) => {
             expect(params.version).eqls(0);
-            return Promise.resolve() as any;
+            return Promise.resolve({ partitions: [] }) as any;
         });
 
         await clientOvverided.getPartitions(

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -52,19 +52,20 @@ describe("VolatileLayerClient", () => {
 
     before(() => {
         sandbox = sinon.createSandbox();
-        let settings = sandbox.createStubInstance(
-            dataServiceRead.OlpClientSettings
-        );
+        let settings = new dataServiceRead.OlpClientSettings({
+            environment: "here",
+            getToken: () => Promise.resolve("token")
+        });
         volatileLayerClient = new dataServiceRead.VolatileLayerClient(
             mockedHRN,
             mockedLayerId,
-            (settings as unknown) as dataServiceRead.OlpClientSettings
+            settings
         );
 
         const volatileLayerClientParams = {
             catalogHrn: mockedHRN,
             layerId: mockedLayerId,
-            settings: (settings as unknown) as dataServiceRead.OlpClientSettings
+            settings
         };
         volatileLayerClientNew = new dataServiceRead.VolatileLayerClient(
             volatileLayerClientParams
@@ -92,7 +93,7 @@ describe("VolatileLayerClient", () => {
         assert.isDefined(volatileLayerClient);
     });
 
-    xit("Should method getPartitions provide data with PartitionsRequest", async () => {
+    it("Should method getPartitions provide data with PartitionsRequest", async () => {
         const mockedPartitions = {
             partitions: [
                 {
@@ -122,7 +123,7 @@ describe("VolatileLayerClient", () => {
         expect(partitions).to.be.equal(mockedPartitions);
     });
 
-    xit("Should method getPartitions provide data with PartitionIds list", async () => {
+    it("Should method getPartitions provide data with PartitionIds list", async () => {
         const mockedIds = ["1", "2", "13", "42"];
         const mockedPartitions = {
             partitions: [
@@ -196,7 +197,7 @@ describe("VolatileLayerClient", () => {
         ).to.be.equal("compressedDataSize");
     });
 
-    xit("Should layerClient sends a QuadKeyPartitionsRequest for getPartitions with additionalFields params", async () => {
+    it("Should layerClient sends a QuadKeyPartitionsRequest for getPartitions with additionalFields params", async () => {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedVersion = {
             version: 42
@@ -653,7 +654,7 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    xit("Should baseUrl error be handled", async () => {
+    it("Should baseUrl error be handled", async () => {
         const mockedErrorResponse = "Bad response";
         const dataRequest = new dataServiceRead.DataRequest().withDataHandle(
             "moсked-data-handle"


### PR DESCRIPTION
Enabled and fixed disabled tests related to the LRU Cache.
Few disabled tests will be fixed in the scope of OLPEDGE-1826

Resolves: OLPEDGE-1795
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>