### PR TITLE
Add support for additional fields in cache

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/metadata-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/metadata-api.ts
@@ -111,6 +111,12 @@ export interface Partition {
      * For volatile partitions this will always be -1
      */
     version: number;
+    /**
+     * Optional value for the CRC of the partition data in bytes.
+     * The response only includes the data size if crc was specified in the additionalFields query parameter,
+     * and if crc was specified in the partition metadata when it was published.
+     */
+    crc?: string;
 }
 
 /**

--- a/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,8 +114,14 @@ export class PartitionsRequest {
     public withAdditionalFields(
         additionalFields: AdditionalFields
     ): PartitionsRequest {
-        this.additionalFields = additionalFields;
-        return this;
+        if (additionalFields.length) {
+            this.additionalFields = additionalFields;
+            return this;
+        } else {
+            throw new Error(
+                "Error. Parameter 'additionalFields' could not contain empty array. Add value or do not use this method."
+            );
+        }
     }
 
     /**

--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -342,7 +342,30 @@ export class VersionedLayerClient {
                 this.layerId
             );
             if (partitions) {
-                return Promise.resolve({ partitions });
+                const additionalFields = request.getAdditionalFields();
+                let existFields;
+                if (additionalFields) {
+                    existFields = additionalFields.filter(
+                        (
+                            field:
+                                | "dataSize"
+                                | "checksum"
+                                | "compressedDataSize"
+                                | "crc"
+                        ) => {
+                            return partitions.every(
+                                partition => partition[field] !== undefined
+                            );
+                        }
+                    );
+                }
+                if (
+                    !additionalFields ||
+                    !existFields ||
+                    additionalFields.length === existFields.length
+                ) {
+                    return Promise.resolve({ partitions });
+                }
             }
         }
 

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -280,7 +280,30 @@ export class VolatileLayerClient {
                 this.layerId
             );
             if (partitions) {
-                return Promise.resolve({ partitions });
+                const additionalFields = request.getAdditionalFields();
+                let existFields;
+                if (additionalFields) {
+                    existFields = additionalFields.filter(
+                        (
+                            field:
+                                | "dataSize"
+                                | "checksum"
+                                | "compressedDataSize"
+                                | "crc"
+                        ) => {
+                            return partitions.every(
+                                partition => partition[field] !== undefined
+                            );
+                        }
+                    );
+                }
+                if (
+                    !additionalFields ||
+                    !existFields ||
+                    additionalFields.length === existFields.length
+                ) {
+                    return Promise.resolve({ partitions });
+                }
             }
         }
 

--- a/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,12 @@ describe("PartitionsRequest", () => {
     const billingTag = "billingTag";
     const mockedVersion = 42;
     const mockedIds = ["1", "2", "13", "42"];
-    const mockedAdditionalFields = ["dataSize","checksum","compressedDataSize","crc"];
+    const mockedAdditionalFields = [
+        "dataSize",
+        "checksum",
+        "compressedDataSize",
+        "crc"
+    ];
 
     it("Should initialize", () => {
         const partitionsRequest = new PartitionsRequest();
@@ -43,14 +48,28 @@ describe("PartitionsRequest", () => {
 
     it("Should set parameters", () => {
         const partitionsRequest = new PartitionsRequest();
-        const partitionsRequestWithVersion = partitionsRequest.withVersion(mockedVersion);
-        const partitionsRequestWithBillTag = partitionsRequest.withBillingTag(billingTag);
-        const partitionsRequestWithIds = partitionsRequest.withPartitionIds(mockedIds);
-        const partitionsAdditionalFields = partitionsRequest.withAdditionalFields(["dataSize","checksum","compressedDataSize","crc"]);
+        const partitionsRequestWithVersion = partitionsRequest.withVersion(
+            mockedVersion
+        );
+        const partitionsRequestWithBillTag = partitionsRequest.withBillingTag(
+            billingTag
+        );
+        const partitionsRequestWithIds = partitionsRequest.withPartitionIds(
+            mockedIds
+        );
+        const partitionsAdditionalFields = partitionsRequest.withAdditionalFields(
+            ["dataSize", "checksum", "compressedDataSize", "crc"]
+        );
 
-        expect(partitionsRequestWithVersion.getVersion()).to.be.equal(mockedVersion);
-        expect(partitionsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
-        expect(partitionsRequestWithIds.getPartitionIds()).to.be.equal(mockedIds);
+        expect(partitionsRequestWithVersion.getVersion()).to.be.equal(
+            mockedVersion
+        );
+        expect(partitionsRequestWithBillTag.getBillingTag()).to.be.equal(
+            billingTag
+        );
+        expect(partitionsRequestWithIds.getPartitionIds()).to.be.equal(
+            mockedIds
+        );
         assert.isDefined(partitionsAdditionalFields.getAdditionalFields());
     });
 
@@ -59,11 +78,29 @@ describe("PartitionsRequest", () => {
             .withVersion(mockedVersion)
             .withBillingTag(billingTag)
             .withPartitionIds(mockedIds)
-            .withAdditionalFields(["dataSize","checksum","compressedDataSize","crc"]);
+            .withAdditionalFields([
+                "dataSize",
+                "checksum",
+                "compressedDataSize",
+                "crc"
+            ]);
 
         expect(partitionsRequest.getVersion()).to.be.equal(mockedVersion);
         expect(partitionsRequest.getBillingTag()).to.be.equal(billingTag);
         expect(partitionsRequest.getPartitionIds()).to.be.equal(mockedIds);
         assert.isDefined(partitionsRequest.getAdditionalFields());
+    });
+
+    it("Should be thrown error if additional fields are empty", () => {
+        try {
+            const partitionsRequest = new PartitionsRequest().withAdditionalFields(
+                []
+            );
+        } catch (error) {
+            assert.equal(
+                error.message,
+                "Error. Parameter 'additionalFields' could not contain empty array. Add value or do not use this method."
+            );
+        }
     });
 });


### PR DESCRIPTION
Updated caching metadata flow.
If request has additional fields than new partitions metadata is fetched and cached.
Updated unit-tests and metadata-api.

Resolves: OLPEDGE-1826
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>