### PR TITLE
Add API to control cache

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/cache/KeyValueCache.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/KeyValueCache.ts
@@ -68,4 +68,32 @@ export class KeyValueCache {
     public remove(key: string): boolean {
         return this.cache.delete(key);
     }
+
+    /**
+     * Clears the cache and removes all stored key-value pairs.
+     */
+    public clear(): void {
+        this.cache.clear();
+    }
+
+    /**
+     * Resets the capacity of this cache. If `newCapacity` is smaller than the current cache size,
+     * all items will be evicted until the cache shrinks to `newCapacity`.
+     *
+     * @param newCapacity The new capacity of this cache.
+     */
+    public setCapacity(newCapacity: number): void {
+        this.cache.setCapacity(newCapacity);
+    }
+
+    /**
+     * Returns the maximum capacity of the cache, i.e. the maximum number of elements this cache
+     * can contain or the total amount of memory that may be consumed by cache if element size
+     * function was specified in cache c-tor.
+     *
+     * @returns The capacity of the cache.
+     */
+    public getCapacity(): number {
+        return this.cache.getCapacity();
+    }
 }

--- a/@here/olp-sdk-dataservice-read/test/unit/KeyValueCache.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/KeyValueCache.test.ts
@@ -14,7 +14,7 @@ describe("KeyValueCache", () => {
         keyValueCache1.put("key2", "value2");
     });
 
-    it("Should put new key value", async () => {
+    it("Should put new key value", () => {
         keyValueCache1.put("key3", "value3");
 
         expect(keyValueCache1.get("key1")).equal("value1");
@@ -22,12 +22,34 @@ describe("KeyValueCache", () => {
         expect(keyValueCache1.get("key3")).equal("value3");
     });
 
-    it("Should get key value", async () => {
+    it("Should put handle error", () => {
+        const cache = new KeyValueCache();
+        const resp1 = cache.put("key", "somedata");
+        expect(resp1).equal(true);
+        cache.setCapacity(0.00000001);
+        const resp2 = cache.put("key", "value");
+        expect(resp2).equal(false);
+    });
+
+    it("Should getCapacity return cache capacity", () => {
+        const cache = new KeyValueCache();
+        expect(cache.getCapacity()).equal(2097152);
+    });
+
+    it("Should clear() clear the cache and remove all ietms", () => {
+        const cache = new KeyValueCache();
+        cache.put("key", "value");
+        expect(cache.get("key")).equal("value");
+        cache.clear();
+        expect(cache.get("key")).equal(undefined);
+    });
+
+    it("Should get key value", () => {
         expect(keyValueCache1.get("key1")).equal("value1");
         expect(keyValueCache1.get("key2")).equal("value2");
     });
 
-    it("Should remove key value", async () => {
+    it("Should remove key value", () => {
         keyValueCache1.remove("key1");
 
         expect(keyValueCache1.get("key1")).equal(undefined);


### PR DESCRIPTION
Add public API to the cache to get capacity,
set capacity and clear the cache.
Also added unit-tests.

Resolves: OLPEDGE-1810
Signed-off-by: ashevchu <ext-andrii.shevchuk@here.com>