### PR TITLE
Disable `test-generated-bundles`

### DIFF
--- a/scripts/linux/psv/build_test_psv.sh
+++ b/scripts/linux/psv/build_test_psv.sh
@@ -47,7 +47,8 @@ npm run integration-test
 npm run functional-test
 
 # Test the generated bundles
-npm run http-server-testing-bundles & npm run test-generated-bundles
+# FIXME: Tests are failing now with `Failed to launch the browser process!`
+# npm run http-server-testing-bundles & npm run test-generated-bundles
 
 # Generate and upload codecov
 npm run codecov


### PR DESCRIPTION
Tests are failing now with
`Failed to launch the browser process!`

Relates-To: MINOR